### PR TITLE
[quests] implement habit completion action

### DIFF
--- a/life_dashboard/quests/application/services.py
+++ b/life_dashboard/quests/application/services.py
@@ -405,9 +405,19 @@ class HabitService:
         if existing_completion:
             raise ValueError(f"Habit already completed on {completion_date}")
 
+        # Determine previous completion to maintain streak calculations
+        previous_completion_date = None
+        recent_completions = self.completion_repo.get_by_habit_id(habit_id, limit=1)
+        if recent_completions:
+            candidate_date = recent_completions[0].completion_date
+            if candidate_date < completion_date:
+                previous_completion_date = candidate_date
+
         # Complete the habit (updates streak)
         experience_gained, new_streak, milestone_reached = habit.complete_habit(
-            completion_date
+            completion_date=completion_date,
+            completion_count=count,
+            previous_completion_date=previous_completion_date,
         )
 
         # Save updated habit

--- a/life_dashboard/quests/domain/entities.py
+++ b/life_dashboard/quests/domain/entities.py
@@ -231,6 +231,26 @@ class Habit:
         streak_bonus = self.calculate_streak_bonus()
         return int(base_reward * streak_bonus)
 
+    def complete_habit(
+        self,
+        completion_date: date,
+        completion_count: int = 1,
+        previous_completion_date: date | None = None,
+    ) -> tuple[int, StreakCount, str | None]:
+        """Apply completion logic and return experience, streak, and milestone information."""
+
+        if completion_count <= 0:
+            raise ValueError("Completion count must be positive")
+
+        self.update_streak(completion_date, previous_completion_date)
+        experience_gained = self.calculate_experience_reward(completion_count)
+        milestone = self.get_streak_milestone_type()
+
+        # Ensure timestamps reflect the completion action
+        self.updated_at = datetime.utcnow()
+
+        return experience_gained, self.current_streak, milestone
+
     def update_streak(
         self, completion_date: date, previous_completion_date: date | None = None
     ) -> None:

--- a/life_dashboard/quests/tests/test_domain_entities.py
+++ b/life_dashboard/quests/tests/test_domain_entities.py
@@ -280,6 +280,34 @@ class TestHabit:
 
         assert habit.current_streak.value == 6
 
+    def test_complete_habit_updates_state_and_returns_details(self):
+        """Test completing a habit returns experience, streak, and milestone data"""
+        habit = Habit(
+            habit_id=HabitId(1),
+            user_id=UserId(1),
+            name=HabitName("Exercise"),
+            description="Daily workout",
+            frequency=HabitFrequency.DAILY,
+            target_count=CompletionCount(1),
+            current_streak=StreakCount(6),
+            longest_streak=StreakCount(10),
+            experience_reward=ExperienceReward(25),
+        )
+
+        today = date.today()
+        yesterday = today - timedelta(days=1)
+
+        experience, streak, milestone = habit.complete_habit(
+            completion_date=today,
+            completion_count=1,
+            previous_completion_date=yesterday,
+        )
+
+        assert experience == habit.calculate_experience_reward(1)
+        assert streak.value == 7
+        assert habit.current_streak.value == 7
+        assert milestone == "week"
+
     def test_habit_streak_update_broken(self):
         """Test habit streak reset when broken"""
         habit = Habit(


### PR DESCRIPTION
## Summary
- add a Habit.complete_habit domain action that updates streaks and returns experience information
- update the application HabitService to supply completion context and use the new domain method
- expand the habit domain entity tests to cover the new completion behaviour

## Testing
- pytest life_dashboard/quests/tests/test_domain_entities.py
- pytest life_dashboard/quests/tests/test_api_snapshots.py *(fails: missing `snapshot` fixture in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cefc46f10883239db8a72968c7b64c