### PR TITLE
[ci] Fix matrix env mapping in workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,16 +116,19 @@ jobs:
           - test-type: domain
             make-target: test-domain
             description: "Pure Domain Tests (Fastest)"
+            env: { HYPOTHESIS_PROFILE: default }
           - test-type: properties
             make-target: test-properties
             description: "Property-Based Tests"
-            env: "HYPOTHESIS_PROFILE=ci"
+            env: { HYPOTHESIS_PROFILE: ci }
           - test-type: contracts
             make-target: test-contracts
             description: "Service Contract Tests"
+            env: { HYPOTHESIS_PROFILE: default }
           - test-type: snapshots
             make-target: test-snapshots
             description: "API Snapshot Tests"
+            env: { HYPOTHESIS_PROFILE: default }
 
     steps:
       - name: Checkout code
@@ -143,8 +146,7 @@ jobs:
 
       - name: Run ${{ matrix.description }}
         run: make ${{ matrix.make-target }}
-        env:
-          HYPOTHESIS_PROFILE: ${{ matrix.test-type == 'properties' && 'ci' || 'default' }}
+        env: ${{ matrix.env }}
         continue-on-error: ${{ github.ref != 'refs/heads/main' }}
 
   comprehensive-testing:


### PR DESCRIPTION
## Summary
- set each domain test matrix entry to provide an environment mapping instead of a string
- reuse the matrix-provided environment object when running the matrix step

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68cefc0e3de88323b1dc63f0504d016b