### PR TITLE
[achievements] Add platinum tier coverage across layers

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ LIFE is a comprehensive, RPG-inspired personal life dashboard that helps you "le
 ### Core RPG System
 - **Core Stats**: Strength, Endurance, Agility, Intelligence, Wisdom, Charisma
 - **Experience Points**: Progression system with leveling
-- **Achievements & Titles**: Bronze, Silver, Gold badges with custom titles
+- **Achievements & Titles**: Bronze, Silver, Gold, Platinum badges with custom titles
 
 ### Life Tracking
 - **Life Stats**: Comprehensive tracking across Health, Wealth, and Relationships

--- a/docs/architecture/bounded-contexts.md
+++ b/docs/architecture/bounded-contexts.md
@@ -81,7 +81,7 @@ The Life Dashboard follows a **Modular Monolith** architecture with strict bound
 **Responsibility**: Achievement and milestone tracking with intelligent triggers.
 
 **Domain Concepts**:
-- Tiered Achievements (Bronze, Silver, Gold)
+- Tiered Achievements (Bronze, Silver, Gold, Platinum)
 - Dynamic achievement rules
 - Titles and badges
 - Cross-context achievement triggers

--- a/life_dashboard/achievements/migrations/0003_alter_achievement_tier_choices.py
+++ b/life_dashboard/achievements/migrations/0003_alter_achievement_tier_choices.py
@@ -1,0 +1,23 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("achievements", "0002_alter_achievement_tier"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="achievement",
+            name="tier",
+            field=models.CharField(
+                choices=[
+                    ("BRONZE", "Bronze"),
+                    ("SILVER", "Silver"),
+                    ("GOLD", "Gold"),
+                    ("PLATINUM", "Platinum"),
+                ],
+                max_length=10,
+            ),
+        ),
+    ]

--- a/life_dashboard/achievements/models.py
+++ b/life_dashboard/achievements/models.py
@@ -3,17 +3,24 @@ from django.core.validators import MinValueValidator
 from django.db import models
 
 
+class AchievementTierChoices(models.TextChoices):
+    """Django choices for achievement tiers."""
+
+    BRONZE = "BRONZE", "Bronze"
+    SILVER = "SILVER", "Silver"
+    GOLD = "GOLD", "Gold"
+    PLATINUM = "PLATINUM", "Platinum"
+
+
 class Achievement(models.Model):
-    TIER_CHOICES = [
-        ("BRONZE", "Bronze"),
-        ("SILVER", "Silver"),
-        ("GOLD", "Gold"),
-        ("PLATINUM", "Platinum"),
-    ]
+    TIER_CHOICES = AchievementTierChoices.choices
 
     name = models.CharField(max_length=200)
     description = models.TextField()
-    tier = models.CharField(max_length=10, choices=TIER_CHOICES)
+    tier = models.CharField(
+        max_length=10,
+        choices=AchievementTierChoices.choices,
+    )
     icon = models.CharField(max_length=50, blank=True)  # For UI icons
     experience_reward = models.IntegerField(
         default=0, validators=[MinValueValidator(0)]

--- a/life_dashboard/dashboard/tests/snapshots/test_api_snapshots/test_user_statistics_response_snapshot/user_statistics_response.json
+++ b/life_dashboard/dashboard/tests/snapshots/test_api_snapshots/test_user_statistics_response_snapshot/user_statistics_response.json
@@ -3,6 +3,7 @@
     "bronze_achievements": 8,
     "completion_rate": 75.0,
     "gold_achievements": 1,
+    "platinum_achievements": 0,
     "silver_achievements": 3,
     "total_achievements": 12
   },

--- a/life_dashboard/dashboard/tests/test_api_snapshots.py
+++ b/life_dashboard/dashboard/tests/test_api_snapshots.py
@@ -224,6 +224,7 @@ class TestDashboardAPISnapshots:
                 "bronze_achievements": 8,
                 "silver_achievements": 3,
                 "gold_achievements": 1,
+                "platinum_achievements": 0,
                 "completion_rate": 75.0,
             },
             "progress_statistics": {

--- a/life_prd.md
+++ b/life_prd.md
@@ -114,7 +114,7 @@ Level tracking
 
 ## . Achievements & Titles
 
-Badges: Bronze, Silver, Gold
+Badges: Bronze, Silver, Gold, Platinum
 
 Custom Titles
 


### PR DESCRIPTION
## Summary
- replace the hard-coded achievement tier tuples with a Django `TextChoices` enum that now includes the Platinum tier and ship a migration to persist the choices
- refresh public docs to mention the Platinum tier alongside the existing Bronze, Silver, and Gold tiers
- extend the dashboard statistics snapshot test data so platinum achievement counts are surfaced in API responses

## Testing
- pytest *(fails: environment is missing optional test dependencies like freezegun, hypothesis, pydantic, pytest_snapshot, and Django isn't fully configured during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68cf04aa35c0832391ac4310f60d4e40