### PR TITLE
[quests] Sanitize quest chain creation data

### DIFF
--- a/life_dashboard/quests/application/services.py
+++ b/life_dashboard/quests/application/services.py
@@ -574,7 +574,6 @@ class HabitService:
         completion_stats = self.completion_repo.get_completion_stats(user_id, days)
 
         stats = {
-        stats = {
             "total_habits": len(habits),
             "active_streaks": len([h for h in habits if h.current_streak.value > 0]),
             "longest_streak": max((h.longest_streak.value for h in habits), default=0),
@@ -618,17 +617,216 @@ class QuestChainService:
         created_quests = []
 
         for quest_data in child_quests:
+            sanitized_quest_data = self._sanitize_child_quest_data(quest_data)
+            timestamp = datetime.utcnow()
             quest = Quest(
                 user_id=user_id,
                 parent_quest_id=parent_quest_id,
-                **quest_data,
-                created_at=datetime.utcnow(),
-                updated_at=datetime.utcnow(),
+                created_at=timestamp,
+                updated_at=timestamp,
+                **sanitized_quest_data,
             )
             created_quest = self.quest_repo.create(quest)
             created_quests.append(created_quest)
 
         return created_quests
+
+    @staticmethod
+    def _normalize_enum(value: Any, enum_cls: type, field_name: str):
+        """Normalize raw enum values to the expected Enum instances."""
+
+        if isinstance(value, enum_cls):
+            return value
+
+        if value is None:
+            raise ValueError(f"{field_name} is required for quest creation.")
+
+        if isinstance(value, str):
+            value = value.strip()
+            if not value:
+                raise ValueError(f"{field_name} cannot be blank.")
+            try:
+                return enum_cls(value)
+            except ValueError:
+                try:
+                    return enum_cls[value.upper()]
+                except KeyError as exc:
+                    raise ValueError(f"Invalid {field_name}: {value}") from exc
+
+        try:
+            return enum_cls(value)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f"Invalid {field_name}: {value}") from exc
+
+    @staticmethod
+    def _normalize_progress(value: Any) -> float:
+        """Ensure quest progress/completion values are floats within 0-100."""
+
+        try:
+            progress_value = float(value)
+        except (TypeError, ValueError) as exc:
+            raise ValueError("progress must be a numeric value") from exc
+
+        if not 0.0 <= progress_value <= 100.0:
+            raise ValueError("progress must be between 0 and 100")
+
+        return progress_value
+
+    @staticmethod
+    def _normalize_date(value: Any, field_name: str) -> date:
+        """Normalize date inputs from strings or datetime objects."""
+
+        if isinstance(value, date) and not isinstance(value, datetime):
+            return value
+
+        if isinstance(value, datetime):
+            return value.date()
+
+        if isinstance(value, str):
+            value = value.strip()
+            if not value:
+                raise ValueError(f"{field_name} cannot be blank")
+            try:
+                return date.fromisoformat(value)
+            except ValueError:
+                try:
+                    return datetime.fromisoformat(value).date()
+                except ValueError as exc:
+                    raise ValueError(
+                        f"{field_name} must be an ISO formatted date string"
+                    ) from exc
+
+        raise ValueError(
+            f"{field_name} must be a date, datetime, or ISO formatted string"
+        )
+
+    @staticmethod
+    def _normalize_datetime(value: Any, field_name: str) -> datetime:
+        """Normalize datetime inputs from strings or dates."""
+
+        if isinstance(value, datetime):
+            return value
+
+        if isinstance(value, date):
+            return datetime.combine(value, datetime.min.time())
+
+        if isinstance(value, str):
+            value = value.strip()
+            if not value:
+                raise ValueError(f"{field_name} cannot be blank")
+            try:
+                return datetime.fromisoformat(value)
+            except ValueError as exc:
+                raise ValueError(
+                    f"{field_name} must be an ISO formatted datetime string"
+                ) from exc
+
+        raise ValueError(
+            f"{field_name} must be a datetime or ISO formatted datetime string"
+        )
+
+    @staticmethod
+    def _normalize_prerequisites(value: Any) -> list[str]:
+        """Normalize prerequisite quest identifiers to a list of strings."""
+
+        if value is None:
+            return []
+
+        if isinstance(value, str):
+            return [value] if value.strip() else []
+
+        if isinstance(value, list | tuple | set):
+            return [str(item) for item in value if str(item).strip()]
+
+        raise ValueError("prerequisite_quest_ids must be a sequence of quest IDs")
+
+    def _sanitize_child_quest_data(self, quest_data: dict[str, Any]) -> dict[str, Any]:
+        """Remove disallowed keys and normalize quest fields."""
+
+        if not isinstance(quest_data, dict):
+            raise ValueError("Each child quest must be provided as a dictionary")
+
+        filtered_data = {
+            key: value
+            for key, value in quest_data.items()
+            if key not in {"user_id", "parent_quest_id", "created_at", "updated_at"}
+        }
+
+        sanitized: dict[str, Any] = {}
+
+        quest_id = filtered_data.pop("quest_id", None)
+        if quest_id is None or not str(quest_id).strip():
+            sanitized["quest_id"] = str(uuid4())
+        else:
+            sanitized["quest_id"] = str(quest_id).strip()
+
+        title = filtered_data.pop("title", None)
+        if title is None or not str(title).strip():
+            raise ValueError("Child quests require a non-empty title")
+        sanitized["title"] = str(title).strip()
+
+        description = filtered_data.pop("description", "")
+        sanitized["description"] = str(description)
+
+        quest_type_value = filtered_data.pop("quest_type", QuestType.MAIN)
+        sanitized["quest_type"] = self._normalize_enum(
+            quest_type_value, QuestType, "quest_type"
+        )
+
+        difficulty_value = filtered_data.pop("difficulty", QuestDifficulty.MEDIUM)
+        sanitized["difficulty"] = self._normalize_enum(
+            difficulty_value, QuestDifficulty, "difficulty"
+        )
+
+        status_value = filtered_data.pop("status", QuestStatus.DRAFT)
+        sanitized["status"] = self._normalize_enum(
+            status_value, QuestStatus, "status"
+        )
+
+        experience_reward = filtered_data.pop("experience_reward", None)
+        if experience_reward is None:
+            raise ValueError("Child quests require an experience_reward value")
+        try:
+            reward_value = int(experience_reward)
+        except (TypeError, ValueError) as exc:
+            raise ValueError("experience_reward must be an integer") from exc
+        if reward_value < 0:
+            raise ValueError("experience_reward cannot be negative")
+        sanitized["experience_reward"] = reward_value
+
+        progress_value = filtered_data.pop("progress", None)
+        completion_percentage = filtered_data.pop("completion_percentage", None)
+        progress_source = (
+            progress_value
+            if progress_value is not None
+            else completion_percentage
+        )
+        if progress_source is not None:
+            sanitized["progress"] = self._normalize_progress(progress_source)
+
+        for date_field in ("start_date", "due_date"):
+            if date_field in filtered_data:
+                sanitized[date_field] = self._normalize_date(
+                    filtered_data.pop(date_field), date_field
+                )
+
+        if "completed_at" in filtered_data:
+            sanitized["completed_at"] = self._normalize_datetime(
+                filtered_data.pop("completed_at"), "completed_at"
+            )
+
+        if "prerequisite_quest_ids" in filtered_data:
+            sanitized["prerequisite_quest_ids"] = self._normalize_prerequisites(
+                filtered_data.pop("prerequisite_quest_ids")
+            )
+
+        if filtered_data:
+            raise ValueError(
+                "Unsupported quest fields provided: "
+                + ", ".join(sorted(filtered_data.keys()))
+            )
+
+        return sanitized
 
     def get_quest_chain(self, parent_quest_id: str) -> list[Quest]:
         """

--- a/life_dashboard/quests/domain/entities.py
+++ b/life_dashboard/quests/domain/entities.py
@@ -78,6 +78,8 @@ class Quest:
     quest_type: QuestType
     status: QuestStatus
     experience_reward: ExperienceReward
+    parent_quest_id: str | None = None
+    prerequisite_quest_ids: list[str] = field(default_factory=list)
     progress: float = 0.0
     start_date: date | None = None
     due_date: date | None = None
@@ -87,6 +89,20 @@ class Quest:
 
     def __post_init__(self):
         """Validate quest data after initialization"""
+        if self.parent_quest_id is not None:
+            self.parent_quest_id = str(self.parent_quest_id)
+
+        if self.prerequisite_quest_ids is None:
+            self.prerequisite_quest_ids = []
+        elif not isinstance(self.prerequisite_quest_ids, list):
+            self.prerequisite_quest_ids = [
+                str(prereq) for prereq in self.prerequisite_quest_ids
+            ]
+        else:
+            self.prerequisite_quest_ids = [
+                str(prereq) for prereq in self.prerequisite_quest_ids
+            ]
+
         self._validate_dates()
         self._validate_status_transitions()
         self._validate_progress()

--- a/life_dashboard/quests/tests/test_quest_chain_service.py
+++ b/life_dashboard/quests/tests/test_quest_chain_service.py
@@ -1,0 +1,119 @@
+"""Tests for QuestChainService child quest creation sanitization."""
+
+from datetime import date, datetime
+from unittest.mock import MagicMock
+
+import pytest
+
+from life_dashboard.quests.application.services import QuestChainService
+from life_dashboard.quests.domain.entities import (
+    QuestDifficulty,
+    QuestStatus,
+    QuestType,
+)
+
+
+class TestQuestChainService:
+    """Test suite for QuestChainService create_quest_chain sanitization."""
+
+    def setup_method(self):
+        """Set up a QuestChainService instance with a mocked repository."""
+
+        self.quest_repo = MagicMock()
+        self.quest_repo.create.side_effect = lambda quest: quest
+        self.service = QuestChainService(self.quest_repo)
+
+    def test_create_quest_chain_sanitizes_and_normalizes_child_data(
+        self, monkeypatch
+    ) -> None:
+        """Quest data is sanitized and normalized before persistence."""
+
+        fixed_now = datetime(2024, 1, 1, 12, 0, 0)
+
+        class FixedDateTime(datetime):
+            @classmethod
+            def utcnow(cls):  # pragma: no cover - trivial override
+                return fixed_now
+
+        monkeypatch.setattr(
+            "life_dashboard.quests.application.services.datetime",
+            FixedDateTime,
+        )
+
+        child_quests = [
+            {
+                "quest_id": "child-123",
+                "title": "  Quest Title  ",
+                "description": "desc",
+                "quest_type": "side",
+                "difficulty": "hard",
+                "status": "completed",
+                "experience_reward": "50",
+                "completion_percentage": "42.5",
+                "start_date": "2024-02-01",
+                "due_date": "2024-02-10",
+                "completed_at": "2024-02-11T00:00:00",
+                "prerequisite_quest_ids": ("pre-1", "pre-2"),
+                # Disallowed keys should be ignored.
+                "user_id": 999,
+                "parent_quest_id": "should-remove",
+                "created_at": "2024-01-01T00:00:00",
+                "updated_at": "2024-01-02T00:00:00",
+            }
+        ]
+
+        created = self.service.create_quest_chain(1, "parent-1", child_quests)
+
+        assert len(created) == 1
+        quest = created[0]
+
+        assert quest.user_id == 1
+        assert quest.parent_quest_id == "parent-1"
+        assert quest.quest_id == "child-123"
+        assert quest.title == "Quest Title"
+        assert quest.description == "desc"
+        assert quest.quest_type == QuestType.SIDE
+        assert quest.difficulty == QuestDifficulty.HARD
+        assert quest.status == QuestStatus.COMPLETED
+        assert quest.experience_reward == 50
+        assert quest.progress == pytest.approx(42.5)
+        assert quest.start_date == date(2024, 2, 1)
+        assert quest.due_date == date(2024, 2, 10)
+        assert quest.completed_at == datetime(2024, 2, 11, 0, 0)
+        assert quest.prerequisite_quest_ids == ["pre-1", "pre-2"]
+        assert quest.created_at == fixed_now
+        assert quest.updated_at == fixed_now
+
+        self.quest_repo.create.assert_called_once()
+
+    def test_create_quest_chain_missing_title_raises_value_error(self) -> None:
+        """A missing title should raise a ValueError before persistence."""
+
+        child_quests = [
+            {
+                "quest_id": "child-123",
+                "experience_reward": 10,
+            }
+        ]
+
+        with pytest.raises(ValueError):
+            self.service.create_quest_chain(1, "parent-1", child_quests)
+
+        self.quest_repo.create.assert_not_called()
+
+    def test_create_quest_chain_invalid_difficulty_raises_value_error(self) -> None:
+        """Invalid difficulty values should be rejected."""
+
+        child_quests = [
+            {
+                "quest_id": "child-123",
+                "title": "Quest Title",
+                "experience_reward": 10,
+                "difficulty": "impossible",
+            }
+        ]
+
+        with pytest.raises(ValueError):
+            self.service.create_quest_chain(1, "parent-1", child_quests)
+
+        self.quest_repo.create.assert_not_called()


### PR DESCRIPTION
## Summary
- sanitize quest chain child payloads before constructing Quest instances and centralize normalization helpers
- extend the Quest domain entity to carry parent and prerequisite identifiers expected by repositories
- cover quest chain sanitization behaviour with dedicated unit tests

## Testing
- pytest life_dashboard/quests/tests/test_quest_chain_service.py
- ruff check life_dashboard/quests

------
https://chatgpt.com/codex/tasks/task_e_68cf072737488323a464c969c37d4351