### PR TITLE
[devops] Fix PR CI triggers

### DIFF
--- a/.github/workflows/architecture-check.yml
+++ b/.github/workflows/architecture-check.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ main, develop ]
   pull_request:
-    branches: [ main, develop ]
+    branches: [ main, develop, 'feature/**' ]
 
 jobs:
   architecture-check:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,8 @@ on:
   pull_request:
     branches:
       - main
+      - develop
+      - 'feature/**'
 
 jobs:
   build:
@@ -68,25 +70,25 @@ jobs:
 
       - name: Run Domain Tests (Fast)
         run: make test-domain-fast
-        continue-on-error: ${{ github.ref != 'refs/heads/main' }}
+        continue-on-error: ${{ github.event_name == 'push' && github.ref != 'refs/heads/main' }}
 
       - name: Run Contract Tests
         run: make test-contracts
-        continue-on-error: ${{ github.ref != 'refs/heads/main' }}
+        continue-on-error: ${{ github.event_name == 'push' && github.ref != 'refs/heads/main' }}
 
       - name: Run Property-Based Tests
         run: make test-properties
-        continue-on-error: ${{ github.ref != 'refs/heads/main' }}
+        continue-on-error: ${{ github.event_name == 'push' && github.ref != 'refs/heads/main' }}
         env:
           HYPOTHESIS_PROFILE: ci
 
       - name: Run Snapshot Tests
         run: make test-snapshots
-        continue-on-error: ${{ github.ref != 'refs/heads/main' }}
+        continue-on-error: ${{ github.event_name == 'push' && github.ref != 'refs/heads/main' }}
 
       - name: Run Integration Tests
         run: pytest -m integration
-        continue-on-error: ${{ github.ref != 'refs/heads/main' }}
+        continue-on-error: ${{ github.event_name == 'push' && github.ref != 'refs/heads/main' }}
         env:
           DJANGO_SETTINGS_MODULE: life_dashboard.life_dashboard.test_settings
 
@@ -147,7 +149,7 @@ jobs:
       - name: Run ${{ matrix.description }}
         run: make ${{ matrix.make-target }}
         env: ${{ matrix.env }}
-        continue-on-error: ${{ github.ref != 'refs/heads/main' }}
+        continue-on-error: ${{ github.event_name == 'push' && github.ref != 'refs/heads/main' }}
 
   comprehensive-testing:
     name: Comprehensive Test Suite


### PR DESCRIPTION
## Summary
- run CI workflows on pull requests targeting develop and feature branches
- ensure PR test jobs fail fast by only allowing continue-on-error for non-main push builds

## Testing
- pytest *(fails: existing NameError for HabitId in quests services)*
- ruff check . *(fails: pre-existing F821 errors in quests services and other modules)*
- mypy life_dashboard *(fails: numerous pre-existing typing errors across the project)*

------
https://chatgpt.com/codex/tasks/task_e_68cf0b0c4ebc83239280d40684d7df3e