### PR TITLE
[quests][achievements] Re-export shared value objects

### DIFF
--- a/life_dashboard/achievements/domain/value_objects.py
+++ b/life_dashboard/achievements/domain/value_objects.py
@@ -7,6 +7,21 @@ No Django dependencies allowed in this module.
 
 from dataclasses import dataclass
 
+from life_dashboard.common.value_objects import ExperienceReward, UserId
+
+__all__ = [
+    "AchievementId",
+    "UserAchievementId",
+    "AchievementName",
+    "AchievementDescription",
+    "RequiredLevel",
+    "RequiredSkillLevel",
+    "RequiredQuestCompletions",
+    "AchievementIcon",
+    "ExperienceReward",
+    "UserId",
+]
+
 
 @dataclass(frozen=True)
 class AchievementId:

--- a/life_dashboard/quests/domain/value_objects.py
+++ b/life_dashboard/quests/domain/value_objects.py
@@ -7,6 +7,20 @@ No Django dependencies allowed in this module.
 
 from dataclasses import dataclass
 
+from life_dashboard.common.value_objects import ExperienceReward, UserId
+
+__all__ = [
+    "QuestId",
+    "QuestTitle",
+    "QuestDescription",
+    "HabitId",
+    "HabitName",
+    "StreakCount",
+    "CompletionCount",
+    "ExperienceReward",
+    "UserId",
+]
+
 
 @dataclass(frozen=True)
 class QuestId:


### PR DESCRIPTION
## Summary
- re-export the shared `ExperienceReward` and `UserId` value objects from the quests domain package
- expose the shared experience and user identifiers via the achievements domain value objects module for downstream imports

## Testing
- make test-snapshots *(fails: pytest exited with code 5 because all snapshot tests were skipped in the local container)*

------
https://chatgpt.com/codex/tasks/task_e_68cfd746535c83239c9c3a4362c2145a