### PR TITLE
[quests] Align experience reward value objects

### DIFF
--- a/life_dashboard/achievements/domain/value_objects.py
+++ b/life_dashboard/achievements/domain/value_objects.py
@@ -7,6 +7,17 @@ No Django dependencies allowed in this module.
 
 from dataclasses import dataclass
 
+from life_dashboard.common.value_objects import (
+    ExperienceReward as _SharedExperienceReward,
+    UserId as _SharedUserId,
+)
+
+# Expose shared value objects through the achievements context to maintain a
+# consistent import surface for domain code and tests while centralizing the
+# canonical definitions in the common package.
+ExperienceReward = _SharedExperienceReward
+UserId = _SharedUserId
+
 
 @dataclass(frozen=True)
 class AchievementId:

--- a/life_dashboard/quests/domain/value_objects.py
+++ b/life_dashboard/quests/domain/value_objects.py
@@ -7,6 +7,17 @@ No Django dependencies allowed in this module.
 
 from dataclasses import dataclass
 
+from life_dashboard.common.value_objects import (
+    ExperienceReward as _SharedExperienceReward,
+    UserId as _SharedUserId,
+)
+
+# Re-export shared value objects within the quests context so domain entities and
+# tests can import them from the local module while keeping the canonical
+# definitions in the common package.
+ExperienceReward = _SharedExperienceReward
+UserId = _SharedUserId
+
 
 @dataclass(frozen=True)
 class QuestId:


### PR DESCRIPTION
## Summary
- re-export the shared ExperienceReward and UserId value objects through the quests domain module
- expose the same shared value objects through the achievements domain module to keep imports consistent

## Testing
- make test-domain-fast

------
https://chatgpt.com/codex/tasks/task_e_68cfd760016c8323811bcc8d0488a795