### PR TITLE
[tests] Stabilize snapshot formatting and skill summary timing

### DIFF
--- a/life_dashboard/achievements/tests/test_api_snapshots.py
+++ b/life_dashboard/achievements/tests/test_api_snapshots.py
@@ -4,7 +4,6 @@ Snapshot tests for Achievements API responses.
 These tests capture API response structures to prevent breaking changes.
 """
 
-import json
 from datetime import datetime, timezone
 from unittest.mock import Mock
 
@@ -13,6 +12,8 @@ import pytest
 pytest.importorskip("pytest_snapshot")
 pytest.importorskip("freezegun")
 from freezegun import freeze_time
+
+from tests.snapshot_utils import assert_json_snapshot
 
 from life_dashboard.achievements.domain.entities import (
     Achievement,
@@ -108,9 +109,8 @@ class TestAchievementAPISnapshots:
         }
 
         # Snapshot the response structure
-        snapshot.assert_match(
-            json.dumps(api_response, indent=2, sort_keys=True),
-            "achievement_creation_response.json",
+        assert_json_snapshot(
+            snapshot, api_response, "achievement_creation_response.json"
         )
 
     @freeze_time("2024-01-15 14:30:00", tz_offset=0)
@@ -183,9 +183,8 @@ class TestAchievementAPISnapshots:
         }
 
         # Snapshot the response structure
-        snapshot.assert_match(
-            json.dumps(api_response, indent=2, sort_keys=True),
-            "unlock_achievement_response.json",
+        assert_json_snapshot(
+            snapshot, api_response, "unlock_achievement_response.json"
         )
 
     def test_achievement_statistics_response_snapshot(self, snapshot):
@@ -306,9 +305,8 @@ class TestAchievementAPISnapshots:
         }
 
         # Snapshot the response structure
-        snapshot.assert_match(
-            json.dumps(api_response, indent=2, sort_keys=True),
-            "achievement_statistics_response.json",
+        assert_json_snapshot(
+            snapshot, api_response, "achievement_statistics_response.json"
         )
 
     def test_achievement_progress_response_snapshot(self, snapshot):
@@ -412,7 +410,6 @@ class TestAchievementAPISnapshots:
         }
 
         # Snapshot the response structure
-        snapshot.assert_match(
-            json.dumps(api_response, indent=2, sort_keys=True),
-            "achievement_progress_response.json",
+        assert_json_snapshot(
+            snapshot, api_response, "achievement_progress_response.json"
         )

--- a/life_dashboard/dashboard/tests/test_api_snapshots.py
+++ b/life_dashboard/dashboard/tests/test_api_snapshots.py
@@ -2,12 +2,13 @@
 Snapshot tests for dashboard API responses - preventing breaking changes.
 """
 
-import json
 from datetime import date, datetime
 
 import pytest
 
 pytest.importorskip("pytest_snapshot")
+
+from tests.snapshot_utils import assert_json_snapshot
 
 from life_dashboard.dashboard.domain.entities import UserProfile
 from life_dashboard.dashboard.domain.state_machines import OnboardingStateMachine
@@ -56,10 +57,7 @@ class TestDashboardAPISnapshots:
             "updated_at": "2023-01-15T14:30:00",
         }
 
-        snapshot.assert_match(
-            json.dumps(response_data, indent=2, sort_keys=True),
-            "user_profile_response.json",
-        )
+        assert_json_snapshot(snapshot, response_data, "user_profile_response.json")
 
     def test_experience_update_response_snapshot(self, snapshot):
         """Test experience update response structure."""
@@ -82,10 +80,7 @@ class TestDashboardAPISnapshots:
             },
         }
 
-        snapshot.assert_match(
-            json.dumps(response_data, indent=2, sort_keys=True),
-            "experience_update_response.json",
-        )
+        assert_json_snapshot(snapshot, response_data, "experience_update_response.json")
 
     def test_onboarding_status_response_snapshot(self, snapshot):
         """Test onboarding status response structure."""
@@ -106,10 +101,7 @@ class TestDashboardAPISnapshots:
             },
         }
 
-        snapshot.assert_match(
-            json.dumps(response_data, indent=2, sort_keys=True),
-            "onboarding_status_response.json",
-        )
+        assert_json_snapshot(snapshot, response_data, "onboarding_status_response.json")
 
     def test_profile_update_response_snapshot(self, snapshot):
         """Test profile update response structure."""
@@ -142,10 +134,7 @@ class TestDashboardAPISnapshots:
             "validation_status": "success",
         }
 
-        snapshot.assert_match(
-            json.dumps(response_data, indent=2, sort_keys=True),
-            "profile_update_response.json",
-        )
+        assert_json_snapshot(snapshot, response_data, "profile_update_response.json")
 
     def test_onboarding_completion_response_snapshot(self, snapshot):
         """Test onboarding completion response structure."""
@@ -184,9 +173,8 @@ class TestDashboardAPISnapshots:
             ],
         }
 
-        snapshot.assert_match(
-            json.dumps(response_data, indent=2, sort_keys=True),
-            "onboarding_completion_response.json",
+        assert_json_snapshot(
+            snapshot, response_data, "onboarding_completion_response.json"
         )
 
     def test_user_statistics_response_snapshot(self, snapshot):
@@ -237,7 +225,4 @@ class TestDashboardAPISnapshots:
             },
         }
 
-        snapshot.assert_match(
-            json.dumps(response_data, indent=2, sort_keys=True),
-            "user_statistics_response.json",
-        )
+        assert_json_snapshot(snapshot, response_data, "user_statistics_response.json")

--- a/life_dashboard/journals/tests/test_api_snapshots.py
+++ b/life_dashboard/journals/tests/test_api_snapshots.py
@@ -2,11 +2,11 @@
 Snapshot tests for journals API responses - preventing breaking changes.
 """
 
-import json
-
 import pytest
 
 pytest.importorskip("pytest_snapshot")
+
+from tests.snapshot_utils import assert_json_snapshot
 
 from life_dashboard.journals.domain.entities import EntryType
 from life_dashboard.journals.domain.services import JournalService
@@ -45,10 +45,7 @@ class TestJournalAPISnapshots:
         response_data["created_at"] = "2023-01-01T12:00:00.000000"
         response_data["updated_at"] = "2023-01-01T12:00:00.000000"
 
-        snapshot.assert_match(
-            json.dumps(response_data, indent=2, sort_keys=True),
-            "journal_entry_creation.json",
-        )
+        assert_json_snapshot(snapshot, response_data, "journal_entry_creation.json")
 
     def test_journal_entry_update_response_snapshot(self, snapshot):
         """Test journal entry update response structure."""
@@ -72,10 +69,7 @@ class TestJournalAPISnapshots:
         response_data["created_at"] = "2023-01-01T12:00:00.000000"
         response_data["updated_at"] = "2023-01-01T13:00:00.000000"
 
-        snapshot.assert_match(
-            json.dumps(response_data, indent=2, sort_keys=True),
-            "journal_entry_update.json",
-        )
+        assert_json_snapshot(snapshot, response_data, "journal_entry_update.json")
 
     def test_mood_statistics_response_snapshot(self, snapshot):
         """Test mood statistics response structure."""
@@ -103,9 +97,7 @@ class TestJournalAPISnapshots:
         if stats["average_mood"] is not None:
             stats["average_mood"] = round(stats["average_mood"], 2)
 
-        snapshot.assert_match(
-            json.dumps(stats, indent=2, sort_keys=True), "mood_statistics.json"
-        )
+        assert_json_snapshot(snapshot, stats, "mood_statistics.json")
 
     def test_journal_entries_list_response_snapshot(self, snapshot):
         """Test journal entries list response structure."""
@@ -161,10 +153,7 @@ class TestJournalAPISnapshots:
         # Sort by entry_id for consistent ordering
         response_data.sort(key=lambda x: x["entry_id"])
 
-        snapshot.assert_match(
-            json.dumps(response_data, indent=2, sort_keys=True),
-            "journal_entries_list.json",
-        )
+        assert_json_snapshot(snapshot, response_data, "journal_entries_list.json")
 
     def test_journal_entry_search_response_snapshot(self, snapshot):
         """Test journal entry search response structure."""
@@ -211,7 +200,4 @@ class TestJournalAPISnapshots:
         # Sort by title for consistent ordering
         response_data.sort(key=lambda x: x["title"])
 
-        snapshot.assert_match(
-            json.dumps(response_data, indent=2, sort_keys=True),
-            "journal_search_results.json",
-        )
+        assert_json_snapshot(snapshot, response_data, "journal_search_results.json")

--- a/life_dashboard/quests/tests/test_api_snapshots.py
+++ b/life_dashboard/quests/tests/test_api_snapshots.py
@@ -4,13 +4,14 @@ Snapshot tests for Quest API responses.
 These tests capture API response structures to prevent breaking changes.
 """
 
-import json
 from datetime import date, datetime
 from unittest.mock import Mock
 
 import pytest
 
 pytest.importorskip("pytest_snapshot")
+
+from tests.snapshot_utils import assert_json_snapshot
 
 from life_dashboard.quests.domain.entities import (
     Habit,
@@ -99,10 +100,7 @@ class TestQuestAPISnapshots:
         }
 
         # Snapshot the response structure
-        snapshot.assert_match(
-            json.dumps(api_response, indent=2, sort_keys=True),
-            "quest_creation_response.json",
-        )
+        assert_json_snapshot(snapshot, api_response, "quest_creation_response.json")
 
     def test_quest_completion_response_snapshot(self, snapshot):
         """Test quest completion API response structure"""
@@ -176,10 +174,7 @@ class TestQuestAPISnapshots:
         }
 
         # Snapshot the response structure
-        snapshot.assert_match(
-            json.dumps(api_response, indent=2, sort_keys=True),
-            "quest_completion_response.json",
-        )
+        assert_json_snapshot(snapshot, api_response, "quest_completion_response.json")
 
     def test_quest_list_response_snapshot(self, snapshot):
         """Test quest list API response structure"""
@@ -251,10 +246,7 @@ class TestQuestAPISnapshots:
         }
 
         # Snapshot the response structure
-        snapshot.assert_match(
-            json.dumps(api_response, indent=2, sort_keys=True),
-            "quest_list_response.json",
-        )
+        assert_json_snapshot(snapshot, api_response, "quest_list_response.json")
 
 
 class TestHabitAPISnapshots:
@@ -314,10 +306,7 @@ class TestHabitAPISnapshots:
         }
 
         # Snapshot the response structure
-        snapshot.assert_match(
-            json.dumps(api_response, indent=2, sort_keys=True),
-            "habit_creation_response.json",
-        )
+        assert_json_snapshot(snapshot, api_response, "habit_creation_response.json")
 
     def test_habit_completion_response_snapshot(self, snapshot):
         """Test habit completion API response structure"""
@@ -380,10 +369,7 @@ class TestHabitAPISnapshots:
         }
 
         # Snapshot the response structure
-        snapshot.assert_match(
-            json.dumps(api_response, indent=2, sort_keys=True),
-            "habit_completion_response.json",
-        )
+        assert_json_snapshot(snapshot, api_response, "habit_completion_response.json")
 
     def test_habit_analytics_response_snapshot(self, snapshot):
         """Test habit analytics API response structure"""
@@ -448,7 +434,4 @@ class TestHabitAPISnapshots:
         }
 
         # Snapshot the response structure
-        snapshot.assert_match(
-            json.dumps(api_response, indent=2, sort_keys=True),
-            "habit_analytics_response.json",
-        )
+        assert_json_snapshot(snapshot, api_response, "habit_analytics_response.json")

--- a/life_dashboard/skills/domain/entities.py
+++ b/life_dashboard/skills/domain/entities.py
@@ -259,12 +259,15 @@ class Skill:
         else:
             return 0.5  # Minimum efficiency
 
-    def is_stagnant(self, days_threshold: int = 30) -> bool:
+    def is_stagnant(
+        self, days_threshold: int = 30, current_time: datetime | None = None
+    ) -> bool:
         """Check if skill has been stagnant (not practiced recently)"""
         if not self.last_practiced:
             return True
 
-        days_since_practice = (datetime.utcnow() - self.last_practiced).days
+        reference_time = current_time or datetime.utcnow()
+        days_since_practice = (reference_time - self.last_practiced).days
         return days_since_practice > days_threshold
 
     def get_milestone_levels(self) -> list[int]:

--- a/life_dashboard/skills/tests/test_api_snapshots.py
+++ b/life_dashboard/skills/tests/test_api_snapshots.py
@@ -4,13 +4,14 @@ Snapshot tests for Skills API responses.
 These tests capture API response structures to prevent breaking changes.
 """
 
-import json
 from datetime import datetime
 from unittest.mock import Mock
 
 import pytest
 
 pytest.importorskip("pytest_snapshot")
+
+from tests.snapshot_utils import assert_json_snapshot
 
 from life_dashboard.skills.domain.entities import (
     Skill,
@@ -66,9 +67,8 @@ class TestSkillCategoryAPISnapshots:
         }
 
         # Snapshot the response structure
-        snapshot.assert_match(
-            json.dumps(api_response, indent=2, sort_keys=True),
-            "category_creation_response.json",
+        assert_json_snapshot(
+            snapshot, api_response, "category_creation_response.json"
         )
 
 
@@ -140,10 +140,7 @@ class TestSkillAPISnapshots:
         }
 
         # Snapshot the response structure
-        snapshot.assert_match(
-            json.dumps(api_response, indent=2, sort_keys=True),
-            "skill_creation_response.json",
-        )
+        assert_json_snapshot(snapshot, api_response, "skill_creation_response.json")
 
     def test_add_experience_response_snapshot(self, snapshot):
         """Test add experience API response structure"""
@@ -210,10 +207,7 @@ class TestSkillAPISnapshots:
         }
 
         # Snapshot the response structure
-        snapshot.assert_match(
-            json.dumps(api_response, indent=2, sort_keys=True),
-            "add_experience_response.json",
-        )
+        assert_json_snapshot(snapshot, api_response, "add_experience_response.json")
 
     def test_practice_skill_response_snapshot(self, snapshot):
         """Test practice skill API response structure"""
@@ -291,10 +285,7 @@ class TestSkillAPISnapshots:
         }
 
         # Snapshot the response structure
-        snapshot.assert_match(
-            json.dumps(api_response, indent=2, sort_keys=True),
-            "practice_skill_response.json",
-        )
+        assert_json_snapshot(snapshot, api_response, "practice_skill_response.json")
 
     def test_skill_progress_summary_response_snapshot(self, snapshot):
         """Test skill progress summary API response structure"""
@@ -360,7 +351,9 @@ class TestSkillAPISnapshots:
         self.mock_skill_repository.get_user_skills.return_value = mock_skills
 
         # Get progress summary
-        summary = self.skill_service.get_skill_progress_summary(UserId(1))
+        summary = self.skill_service.get_skill_progress_summary(
+            UserId(1), current_time=datetime(2024, 1, 15, 18, 0, 0)
+        )
 
         # Convert to API response format (summary is already in the right format)
         api_response = {
@@ -382,9 +375,8 @@ class TestSkillAPISnapshots:
         }
 
         # Snapshot the response structure
-        snapshot.assert_match(
-            json.dumps(api_response, indent=2, sort_keys=True),
-            "skill_progress_summary_response.json",
+        assert_json_snapshot(
+            snapshot, api_response, "skill_progress_summary_response.json"
         )
 
     def test_skill_list_response_snapshot(self, snapshot):
@@ -502,7 +494,4 @@ class TestSkillAPISnapshots:
         }
 
         # Snapshot the response structure
-        snapshot.assert_match(
-            json.dumps(api_response, indent=2, sort_keys=True),
-            "skill_list_response.json",
-        )
+        assert_json_snapshot(snapshot, api_response, "skill_list_response.json")

--- a/tests/snapshot_utils.py
+++ b/tests/snapshot_utils.py
@@ -1,0 +1,13 @@
+"""Utilities for working with snapshot tests."""
+
+import json
+from typing import Any
+
+
+def assert_json_snapshot(snapshot: Any, data: Any, filename: str) -> None:
+    """Serialize data to formatted JSON and assert snapshot match.
+
+    Adds a trailing newline to keep compatibility with stored snapshots.
+    """
+    serialized = json.dumps(data, indent=2, sort_keys=True) + "\n"
+    snapshot.assert_match(serialized, filename)


### PR DESCRIPTION
## Summary
- add a shared JSON snapshot helper to ensure serialized data includes the trailing newline expected by stored fixtures
- update dashboard, journal, quest, achievement, and skill snapshot tests to reuse the helper and supply a deterministic time for skill progress summaries
- allow `Skill.is_stagnant` and `SkillService.get_skill_progress_summary` to accept an optional `current_time` for stable calculations

## Testing
- make test-snapshots *(fails: `pytest_snapshot` plugin unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cfd8dd1eb083238aa7e9dad7f5cfb7