### PR TITLE
Add domain services for skill and achievement summaries

### DIFF
--- a/life_dashboard/achievements/domain/__init__.py
+++ b/life_dashboard/achievements/domain/__init__.py
@@ -1,0 +1,8 @@
+"""Domain layer exports for achievements."""
+
+from .services import AchievementProgressService, build_achievement_progress_response
+
+__all__ = [
+    "AchievementProgressService",
+    "build_achievement_progress_response",
+]

--- a/life_dashboard/achievements/domain/entities.py
+++ b/life_dashboard/achievements/domain/entities.py
@@ -25,5 +25,10 @@ class AchievementTracker:
         return [a for a in self.achievements if a.completion_percentage < 100]
 
     def highest_reward(self) -> int:
-        rewards = [a.potential_reward for a in self.achievements if a.potential_reward]
+        rewards = [achievement.reward_points for achievement in self.achievements]
+        rewards.extend(
+            achievement.potential_reward
+            for achievement in self.achievements
+            if achievement.potential_reward is not None
+        )
         return max(rewards) if rewards else 0

--- a/life_dashboard/achievements/domain/entities.py
+++ b/life_dashboard/achievements/domain/entities.py
@@ -1,0 +1,29 @@
+"""Domain entities for achievements."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+
+from .value_objects import AchievementProgress, UserIdentifier
+
+
+@dataclass(frozen=True)
+class AchievementTracker:
+    """Collection of achievements currently tracked for a user."""
+
+    user_id: UserIdentifier
+    achievements: tuple[AchievementProgress, ...]
+
+    def __iter__(self) -> Iterable[AchievementProgress]:
+        return iter(self.achievements)
+
+    def completed(self) -> list[AchievementProgress]:
+        return [a for a in self.achievements if a.completion_percentage >= 100]
+
+    def in_progress(self) -> list[AchievementProgress]:
+        return [a for a in self.achievements if a.completion_percentage < 100]
+
+    def highest_reward(self) -> int:
+        rewards = [a.potential_reward for a in self.achievements if a.potential_reward]
+        return max(rewards) if rewards else 0

--- a/life_dashboard/achievements/domain/repositories.py
+++ b/life_dashboard/achievements/domain/repositories.py
@@ -1,0 +1,16 @@
+"""Repository interfaces for achievements domain."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from .entities import AchievementTracker
+from .value_objects import UserIdentifier
+
+
+class AchievementRepository(ABC):
+    """Repository providing access to achievements progress."""
+
+    @abstractmethod
+    def tracker_for_user(self, user_id: UserIdentifier) -> AchievementTracker:
+        """Return the achievement tracker for the supplied user."""

--- a/life_dashboard/achievements/domain/services.py
+++ b/life_dashboard/achievements/domain/services.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Optional
 
 from .entities import AchievementTracker
 from .repositories import AchievementRepository
@@ -91,7 +90,7 @@ class AchievementProgressService:
     def generate(
         self,
         user_id: int,
-        as_of: Optional[datetime] = None,
+        as_of: datetime | None = None,
     ) -> AchievementProgressResponse:
         tracker = self._repository.tracker_for_user(UserIdentifier(user_id))
         tracked, completed = self._build_snapshots(tracker)
@@ -111,7 +110,7 @@ class AchievementProgressService:
 def build_achievement_progress_response(
     service: AchievementProgressService,
     user_id: int,
-    as_of: Optional[datetime] = None,
+    as_of: datetime | None = None,
 ) -> dict[str, object]:
     response = service.generate(user_id=user_id, as_of=as_of)
     return response.as_dict()

--- a/life_dashboard/achievements/domain/services.py
+++ b/life_dashboard/achievements/domain/services.py
@@ -1,0 +1,117 @@
+"""Domain services for achievement progress reporting."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Optional
+
+from .entities import AchievementTracker
+from .repositories import AchievementRepository
+from .value_objects import UserIdentifier
+
+
+@dataclass(frozen=True)
+class AchievementProgressSnapshot:
+    name: str
+    description: str
+    tier: str
+    completion_percentage: float
+    reward_points: int
+    remaining_progress: int
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "name": self.name,
+            "description": self.description,
+            "tier": self.tier,
+            "completion_percentage": self.completion_percentage,
+            "reward_points": self.reward_points,
+            "remaining_progress": self.remaining_progress,
+        }
+
+
+@dataclass(frozen=True)
+class AchievementProgressSummary:
+    tracked: list[AchievementProgressSnapshot]
+    completed: list[AchievementProgressSnapshot]
+    highest_potential_reward: int
+    total_tracked: int
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "tracked": [item.as_dict() for item in self.tracked],
+            "completed": [item.as_dict() for item in self.completed],
+            "highest_potential_reward": self.highest_potential_reward,
+            "total_tracked": self.total_tracked,
+        }
+
+
+@dataclass(frozen=True)
+class AchievementProgressResponse:
+    user_id: int
+    generated_at: datetime
+    achievement_progress: AchievementProgressSummary
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "user_id": self.user_id,
+            "generated_at": self.generated_at.isoformat(),
+            "achievement_progress": self.achievement_progress.as_dict(),
+        }
+
+
+class AchievementProgressService:
+    """Service orchestrating achievement progress summary generation."""
+
+    def __init__(self, achievement_repository: AchievementRepository) -> None:
+        self._repository = achievement_repository
+
+    def _build_snapshots(
+        self,
+        tracker: AchievementTracker,
+    ) -> tuple[list[AchievementProgressSnapshot], list[AchievementProgressSnapshot]]:
+        completed: list[AchievementProgressSnapshot] = []
+        tracked: list[AchievementProgressSnapshot] = []
+        for achievement in tracker.achievements:
+            snapshot = AchievementProgressSnapshot(
+                name=achievement.name,
+                description=achievement.description,
+                tier=achievement.tier,
+                completion_percentage=round(achievement.completion_percentage, 2),
+                reward_points=achievement.reward_points,
+                remaining_progress=achievement.remaining_progress,
+            )
+            if achievement.completion_percentage >= 100:
+                completed.append(snapshot)
+            else:
+                tracked.append(snapshot)
+        return tracked, completed
+
+    def generate(
+        self,
+        user_id: int,
+        as_of: Optional[datetime] = None,
+    ) -> AchievementProgressResponse:
+        tracker = self._repository.tracker_for_user(UserIdentifier(user_id))
+        tracked, completed = self._build_snapshots(tracker)
+        summary = AchievementProgressSummary(
+            tracked=tracked,
+            completed=completed,
+            highest_potential_reward=tracker.highest_reward(),
+            total_tracked=len(tracker.achievements),
+        )
+        return AchievementProgressResponse(
+            user_id=user_id,
+            generated_at=as_of or datetime.utcnow(),
+            achievement_progress=summary,
+        )
+
+
+def build_achievement_progress_response(
+    service: AchievementProgressService,
+    user_id: int,
+    as_of: Optional[datetime] = None,
+) -> dict[str, object]:
+    response = service.generate(user_id=user_id, as_of=as_of)
+    return response.as_dict()

--- a/life_dashboard/achievements/domain/value_objects.py
+++ b/life_dashboard/achievements/domain/value_objects.py
@@ -1,0 +1,56 @@
+"""Value objects for achievements domain."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass(frozen=True)
+class UserIdentifier:
+    value: int
+
+    def __post_init__(self) -> None:
+        if self.value <= 0:
+            raise ValueError("User identifier must be positive")
+
+
+@dataclass(frozen=True)
+class AchievementIdentifier:
+    value: str
+
+    def __post_init__(self) -> None:
+        if not self.value:
+            raise ValueError("Achievement identifier cannot be empty")
+
+
+@dataclass(frozen=True)
+class AchievementProgress:
+    """Represents tracked progress toward an achievement."""
+
+    name: str
+    description: str
+    tier: str
+    current_progress: int
+    target_progress: int
+    reward_points: int
+    potential_reward: Optional[int]
+
+    def __post_init__(self) -> None:
+        if self.current_progress < 0:
+            raise ValueError("Progress cannot be negative")
+        if self.target_progress <= 0:
+            raise ValueError("Target must be positive")
+        if self.reward_points < 0:
+            raise ValueError("Reward points cannot be negative")
+        if self.potential_reward is not None and self.potential_reward < 0:
+            raise ValueError("Potential reward cannot be negative")
+
+    @property
+    def completion_percentage(self) -> float:
+        percentage = (self.current_progress / self.target_progress) * 100
+        return max(0.0, min(100.0, percentage))
+
+    @property
+    def remaining_progress(self) -> int:
+        return max(0, self.target_progress - self.current_progress)

--- a/life_dashboard/achievements/domain/value_objects.py
+++ b/life_dashboard/achievements/domain/value_objects.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Optional
 
 
 @dataclass(frozen=True)
@@ -34,7 +33,7 @@ class AchievementProgress:
     current_progress: int
     target_progress: int
     reward_points: int
-    potential_reward: Optional[int]
+    potential_reward: int | None
 
     def __post_init__(self) -> None:
         if self.current_progress < 0:

--- a/life_dashboard/skills/domain/__init__.py
+++ b/life_dashboard/skills/domain/__init__.py
@@ -1,0 +1,8 @@
+"""Domain layer for the skills bounded context."""
+
+from .services import SkillProgressSummaryService, build_skill_progress_summary_response
+
+__all__ = [
+    "SkillProgressSummaryService",
+    "build_skill_progress_summary_response",
+]

--- a/life_dashboard/skills/domain/entities.py
+++ b/life_dashboard/skills/domain/entities.py
@@ -1,0 +1,83 @@
+"""Domain entities for the skills context."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Iterable, Optional
+
+from .value_objects import PracticeSession, SkillIdentifier, SkillProgress, UserIdentifier
+
+
+@dataclass(frozen=True)
+class SkillProfile:
+    """Aggregate representing a user's relationship with a particular skill."""
+
+    skill_id: SkillIdentifier
+    user_id: UserIdentifier
+    name: str
+    category: str
+    progress: SkillProgress
+
+    def __post_init__(self) -> None:
+        if not self.name:
+            raise ValueError("Skill name cannot be empty")
+        if not self.category:
+            raise ValueError("Skill category cannot be empty")
+
+    @property
+    def current_level(self) -> int:
+        return self.progress.current_level
+
+    @property
+    def experience_points(self) -> int:
+        return self.progress.experience_points
+
+    @property
+    def last_practiced(self) -> Optional[datetime]:
+        return self.progress.last_practiced
+
+    def progress_percentage(self, additional_progress: int = 0) -> float:
+        return self.progress.progress_percentage(additional_progress)
+
+    def next_milestone(self) -> int:
+        return self.progress.next_milestone()
+
+    def days_since_practice(self, reference: datetime) -> Optional[int]:
+        return self.progress.days_since_practice(reference)
+
+
+@dataclass(frozen=True)
+class SkillPortfolio:
+    """Aggregate collection of skills belonging to a user."""
+
+    user_id: UserIdentifier
+    skills: tuple[SkillProfile, ...]
+
+    def __post_init__(self) -> None:
+        skill_user_ids = {skill.user_id for skill in self.skills}
+        if skill_user_ids and skill_user_ids != {self.user_id}:
+            raise ValueError("All skills must belong to the portfolio owner")
+
+    def __iter__(self) -> Iterable[SkillProfile]:
+        return iter(self.skills)
+
+    def total_experience(self) -> int:
+        return sum(skill.experience_points for skill in self.skills)
+
+    def total_skills(self) -> int:
+        return len(self.skills)
+
+
+@dataclass(frozen=True)
+class PracticeHistory:
+    """Collection of practice sessions grouped per user."""
+
+    user_id: UserIdentifier
+    sessions: tuple[PracticeSession, ...]
+
+    def __iter__(self) -> Iterable[PracticeSession]:
+        return iter(self.sessions)
+
+    def sessions_for_skill(self, skill_id: SkillIdentifier) -> tuple[PracticeSession, ...]:
+        return tuple(session for session in self.sessions if session.skill_id == skill_id)

--- a/life_dashboard/skills/domain/entities.py
+++ b/life_dashboard/skills/domain/entities.py
@@ -4,9 +4,14 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Iterable, Optional
+from typing import Iterable
 
-from .value_objects import PracticeSession, SkillIdentifier, SkillProgress, UserIdentifier
+from .value_objects import (
+    PracticeSession,
+    SkillIdentifier,
+    SkillProgress,
+    UserIdentifier,
+)
 
 
 @dataclass(frozen=True)
@@ -34,7 +39,7 @@ class SkillProfile:
         return self.progress.experience_points
 
     @property
-    def last_practiced(self) -> Optional[datetime]:
+    def last_practiced(self) -> datetime | None:
         return self.progress.last_practiced
 
     def progress_percentage(self, additional_progress: int = 0) -> float:
@@ -43,7 +48,7 @@ class SkillProfile:
     def next_milestone(self) -> int:
         return self.progress.next_milestone()
 
-    def days_since_practice(self, reference: datetime) -> Optional[int]:
+    def days_since_practice(self, reference: datetime) -> int | None:
         return self.progress.days_since_practice(reference)
 
 
@@ -79,5 +84,9 @@ class PracticeHistory:
     def __iter__(self) -> Iterable[PracticeSession]:
         return iter(self.sessions)
 
-    def sessions_for_skill(self, skill_id: SkillIdentifier) -> tuple[PracticeSession, ...]:
-        return tuple(session for session in self.sessions if session.skill_id == skill_id)
+    def sessions_for_skill(
+        self, skill_id: SkillIdentifier
+    ) -> tuple[PracticeSession, ...]:
+        return tuple(
+            session for session in self.sessions if session.skill_id == skill_id
+        )

--- a/life_dashboard/skills/domain/repositories.py
+++ b/life_dashboard/skills/domain/repositories.py
@@ -1,0 +1,24 @@
+"""Repository interfaces for the skills domain."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from .entities import PracticeHistory, SkillPortfolio
+from .value_objects import UserIdentifier
+
+
+class SkillRepository(ABC):
+    """Abstract repository that provides access to skill data."""
+
+    @abstractmethod
+    def portfolio_for_user(self, user_id: UserIdentifier) -> SkillPortfolio:
+        """Return the portfolio of skills for a user."""
+
+
+class PracticeRepository(ABC):
+    """Abstract repository providing practice sessions."""
+
+    @abstractmethod
+    def history_for_user(self, user_id: UserIdentifier) -> PracticeHistory:
+        """Return the practice history for the supplied user."""

--- a/life_dashboard/skills/domain/services.py
+++ b/life_dashboard/skills/domain/services.py
@@ -1,0 +1,304 @@
+"""Domain services for producing skill analytics summaries."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import Optional
+
+from .entities import PracticeHistory, SkillPortfolio, SkillProfile
+from .repositories import PracticeRepository, SkillRepository
+from .value_objects import PracticeSession, UserIdentifier
+
+
+@dataclass(frozen=True)
+class RecommendedAction:
+    """Actionable recommendation for the user."""
+
+    description: str
+    priority: str
+    reason: str
+
+    def as_dict(self) -> dict[str, str]:
+        return {
+            "description": self.description,
+            "priority": self.priority,
+            "reason": self.reason,
+        }
+
+
+@dataclass(frozen=True)
+class SkillProgressSnapshot:
+    """Snapshot of a skill's current progress."""
+
+    skill_name: str
+    current_level: int
+    next_milestone: int
+    progress_percentage: float
+
+    def as_dict(self) -> dict[str, float | int | str]:
+        return {
+            "skill_name": self.skill_name,
+            "current_level": self.current_level,
+            "next_milestone": self.next_milestone,
+            "progress_percentage": self.progress_percentage,
+        }
+
+
+@dataclass(frozen=True)
+class StagnantSkill:
+    """Represents a skill that has not been practiced recently."""
+
+    name: str
+    level: int
+    days_since_practice: int
+
+    def as_dict(self) -> dict[str, int | str]:
+        return {
+            "name": self.name,
+            "level": self.level,
+            "days_since_practice": self.days_since_practice,
+        }
+
+
+@dataclass(frozen=True)
+class TopSkill:
+    """Represents a high performing skill."""
+
+    name: str
+    level: int
+    mastery: str
+    rank: str
+
+    def as_dict(self) -> dict[str, str | int]:
+        return {
+            "name": self.name,
+            "level": self.level,
+            "mastery": self.mastery,
+            "rank": self.rank,
+        }
+
+
+@dataclass(frozen=True)
+class SkillProgressSummary:
+    """Domain DTO representing an aggregated view of the user's skills."""
+
+    top_skills: list[TopSkill]
+    stagnant_skills: list[StagnantSkill]
+    active_skills: list[SkillProgressSnapshot]
+    total_experience: int
+    total_skills: int
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "top_skills": [skill.as_dict() for skill in self.top_skills],
+            "stagnant_skills": [skill.as_dict() for skill in self.stagnant_skills],
+            "active_skills": [skill.as_dict() for skill in self.active_skills],
+            "total_experience": self.total_experience,
+            "total_skills": self.total_skills,
+        }
+
+
+@dataclass(frozen=True)
+class SkillProgressSummaryResponse:
+    """Full API response representation."""
+
+    user_id: int
+    summary_generated_at: datetime
+    skill_progress_summary: SkillProgressSummary
+    recommended_actions: list[RecommendedAction]
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "user_id": self.user_id,
+            "summary_generated_at": self.summary_generated_at.isoformat(),
+            "skill_progress_summary": self.skill_progress_summary.as_dict(),
+            "recommended_actions": [action.as_dict() for action in self.recommended_actions],
+        }
+
+
+class SkillProgressSummaryService:
+    """Build skill progress summaries using repositories."""
+
+    def __init__(
+        self,
+        skill_repository: SkillRepository,
+        practice_repository: PracticeRepository,
+        recency_window: timedelta | None = None,
+        stagnation_threshold: timedelta | None = None,
+    ) -> None:
+        self._skills = skill_repository
+        self._practice = practice_repository
+        self._recency_window = recency_window or timedelta(days=30)
+        self._stagnation_threshold = stagnation_threshold or timedelta(days=30)
+
+    def _recent_experience_by_skill(
+        self,
+        history: PracticeHistory,
+        as_of: datetime,
+    ) -> dict[str, int]:
+        """Group practice experience by skill within the recent window."""
+
+        lower_bound = as_of - self._recency_window
+        grouped: dict[str, int] = defaultdict(int)
+        for session in history:
+            if session.practiced_at > as_of:
+                continue
+            if session.practiced_at < lower_bound:
+                continue
+            grouped[session.skill_id.value] += session.experience_gained
+        return grouped
+
+    def _stagnant_skills(
+        self,
+        portfolio: SkillPortfolio,
+        as_of: datetime,
+    ) -> list[StagnantSkill]:
+        stagnant: list[StagnantSkill] = []
+        threshold_days = self._stagnation_threshold.days
+        for skill in portfolio:
+            days = skill.days_since_practice(as_of)
+            if days is None or days < threshold_days:
+                continue
+            stagnant.append(
+                StagnantSkill(
+                    name=skill.name,
+                    level=skill.current_level,
+                    days_since_practice=days,
+                )
+            )
+        stagnant.sort(key=lambda entry: entry.days_since_practice, reverse=True)
+        return stagnant
+
+    @staticmethod
+    def _determine_mastery(level: int) -> tuple[str, str]:
+        if level >= 80:
+            return "master", "Master"
+        if level >= 60:
+            return "expert", "Expert"
+        if level >= 40:
+            return "veteran", "Seasoned Adventurer"
+        if level >= 30:
+            return "apprentice", "Advanced Apprentice"
+        if level >= 20:
+            return "apprentice", "Skilled Apprentice"
+        return "novice", "Developing"
+
+    def _top_skills(self, portfolio: SkillPortfolio) -> list[TopSkill]:
+        sorted_skills = sorted(
+            portfolio,
+            key=lambda skill: (skill.current_level, skill.experience_points),
+            reverse=True,
+        )
+        top_entries: list[TopSkill] = []
+        for skill in sorted_skills[:5]:
+            mastery, rank = self._determine_mastery(skill.current_level)
+            if mastery == "apprentice" and skill.current_level < 30:
+                rank = "Skilled Apprentice"
+            top_entries.append(
+                TopSkill(
+                    name=skill.name,
+                    level=skill.current_level,
+                    mastery=mastery,
+                    rank=rank,
+                )
+            )
+        return top_entries
+
+    def _active_skills(
+        self,
+        portfolio: SkillPortfolio,
+        recent_xp: dict[str, int],
+    ) -> list[SkillProgressSnapshot]:
+        snapshots: list[SkillProgressSnapshot] = []
+        for skill in portfolio:
+            xp_gain = recent_xp.get(skill.skill_id.value, 0)
+            progress = skill.progress_percentage(xp_gain)
+            snapshots.append(
+                SkillProgressSnapshot(
+                    skill_name=skill.name,
+                    current_level=skill.current_level,
+                    next_milestone=skill.next_milestone(),
+                    progress_percentage=progress,
+                )
+            )
+        snapshots.sort(key=lambda item: item.progress_percentage, reverse=True)
+        return snapshots[:5]
+
+    def _recommended_actions(
+        self,
+        stagnant: list[StagnantSkill],
+        active: list[SkillProgressSnapshot],
+    ) -> list[RecommendedAction]:
+        actions: list[RecommendedAction] = []
+        if stagnant:
+            first = stagnant[0]
+            urgency = "high" if first.days_since_practice >= 45 else "medium"
+            actions.append(
+                RecommendedAction(
+                    description=f"Schedule practice session for {first.name}",
+                    priority=urgency,
+                    reason=f"No activity for {first.days_since_practice} days",
+                )
+            )
+        if len(active) >= 1:
+            focus_skill = active[0]
+            actions.append(
+                RecommendedAction(
+                    description=f"Push {focus_skill.skill_name} to level {focus_skill.next_milestone}",
+                    priority="medium",
+                    reason="Strong momentum towards next milestone",
+                )
+            )
+        if len(active) >= 2:
+            maint = active[-1]
+            actions.append(
+                RecommendedAction(
+                    description=f"Maintain fundamentals in {maint.skill_name}",
+                    priority="low",
+                    reason="Consistent small gains keep mastery sharp",
+                )
+            )
+        return actions
+
+    def generate_summary(
+        self,
+        user_id: int,
+        as_of: Optional[datetime] = None,
+    ) -> SkillProgressSummaryResponse:
+        as_of = as_of or datetime.utcnow()
+        user_identifier = UserIdentifier(user_id)
+        portfolio = self._skills.portfolio_for_user(user_identifier)
+        history = self._practice.history_for_user(user_identifier)
+
+        recent_xp = self._recent_experience_by_skill(history, as_of)
+        active_skills = self._active_skills(portfolio, recent_xp)
+        stagnant = self._stagnant_skills(portfolio, as_of)
+        top_skills = self._top_skills(portfolio)
+
+        summary = SkillProgressSummary(
+            top_skills=top_skills,
+            stagnant_skills=stagnant,
+            active_skills=active_skills,
+            total_experience=portfolio.total_experience(),
+            total_skills=portfolio.total_skills(),
+        )
+        actions = self._recommended_actions(stagnant, active_skills)
+        return SkillProgressSummaryResponse(
+            user_id=user_id,
+            summary_generated_at=as_of,
+            skill_progress_summary=summary,
+            recommended_actions=actions,
+        )
+
+
+def build_skill_progress_summary_response(
+    service: SkillProgressSummaryService,
+    user_id: int,
+    as_of: Optional[datetime] = None,
+) -> dict[str, object]:
+    """Utility helper returning a serialisable summary for tests/API."""
+
+    response = service.generate_summary(user_id=user_id, as_of=as_of)
+    return response.as_dict()

--- a/life_dashboard/skills/domain/value_objects.py
+++ b/life_dashboard/skills/domain/value_objects.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Optional
 
 
 @dataclass(frozen=True)
@@ -50,7 +49,7 @@ class SkillProgress:
     experience_points: int
     experience_to_next_level: int
     progress_points: int
-    last_practiced: Optional[datetime]
+    last_practiced: datetime | None
 
     def __post_init__(self) -> None:
         if self.current_level < 0:
@@ -77,7 +76,7 @@ class SkillProgress:
         percentage = (total_progress / self.experience_to_next_level) * 100
         return max(0.0, min(100.0, percentage))
 
-    def days_since_practice(self, reference: datetime) -> Optional[int]:
+    def days_since_practice(self, reference: datetime) -> int | None:
         """Return the number of days since the skill was last practiced."""
 
         if self.last_practiced is None:

--- a/life_dashboard/skills/domain/value_objects.py
+++ b/life_dashboard/skills/domain/value_objects.py
@@ -1,0 +1,86 @@
+"""Value objects used by the skills domain services."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Optional
+
+
+@dataclass(frozen=True)
+class SkillIdentifier:
+    """Strongly typed identifier for a skill."""
+
+    value: str
+
+    def __post_init__(self) -> None:
+        if not self.value:
+            raise ValueError("Skill identifier cannot be empty")
+
+
+@dataclass(frozen=True)
+class UserIdentifier:
+    """Strongly typed identifier for the user owner of a skill."""
+
+    value: int
+
+    def __post_init__(self) -> None:
+        if self.value <= 0:
+            raise ValueError("User identifier must be positive")
+
+
+@dataclass(frozen=True)
+class PracticeSession:
+    """Representation of a single practice session for a skill."""
+
+    skill_id: SkillIdentifier
+    practiced_at: datetime
+    experience_gained: int
+
+    def __post_init__(self) -> None:
+        if self.experience_gained < 0:
+            raise ValueError("Experience gained cannot be negative")
+
+
+@dataclass(frozen=True)
+class SkillProgress:
+    """Represents the progress a skill has made towards the next milestone."""
+
+    current_level: int
+    experience_points: int
+    experience_to_next_level: int
+    progress_points: int
+    last_practiced: Optional[datetime]
+
+    def __post_init__(self) -> None:
+        if self.current_level < 0:
+            raise ValueError("Skill level cannot be negative")
+        if self.experience_points < 0:
+            raise ValueError("Experience points cannot be negative")
+        if self.experience_to_next_level <= 0:
+            raise ValueError("Experience to next level must be positive")
+        if self.progress_points < 0:
+            raise ValueError("Progress points cannot be negative")
+
+    def next_milestone(self, milestone_interval: int = 5) -> int:
+        """Return the next milestone level for the skill."""
+
+        remainder = self.current_level % milestone_interval
+        if remainder == 0:
+            return self.current_level + milestone_interval
+        return self.current_level + (milestone_interval - remainder)
+
+    def progress_percentage(self, additional_progress: int = 0) -> float:
+        """Return the progress percentage including extra experience."""
+
+        total_progress = self.progress_points + max(additional_progress, 0)
+        percentage = (total_progress / self.experience_to_next_level) * 100
+        return max(0.0, min(100.0, percentage))
+
+    def days_since_practice(self, reference: datetime) -> Optional[int]:
+        """Return the number of days since the skill was last practiced."""
+
+        if self.last_practiced is None:
+            return None
+        delta = reference - self.last_practiced
+        return max(0, delta.days)


### PR DESCRIPTION
## Summary
- add a domain layer structure for the skills context with entities, repositories, and services to build summary responses
- add an analogous domain layer for the achievements context with response helpers

## Testing
- python -m py_compile $(git ls-files '*.py')

------
https://chatgpt.com/codex/tasks/task_e_68cfe14ea8b48323a2e0d90562b8bed8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Achievements: View a consolidated progress report with completed vs in‑progress achievements, remaining steps, and highest potential reward, time‑stamped for clarity.
  - Skills: Get a rich skills summary, including top skills, active skills, and skills needing attention based on recent practice, plus totals for skills and experience.
  - Guidance: Receive recommended actions tailored to your recent activity and stagnation to help prioritise what to do next.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->