### PR TITLE
[tests] Refresh skills and achievements snapshots

### DIFF
--- a/life_dashboard/achievements/tests/snapshots/test_api_snapshots/test_achievement_progress_response_snapshot/achievement_progress_response.json
+++ b/life_dashboard/achievements/tests/snapshots/test_api_snapshots/test_achievement_progress_response_snapshot/achievement_progress_response.json
@@ -38,7 +38,6 @@
     "average_progress": 60.0,
     "close_to_completion": 1,
     "eligible_to_unlock": 0,
-    "highest_potential_reward": 15000,
     "total_tracked": 2
   },
   "user_id": 1

--- a/life_dashboard/skills/tests/snapshots/test_api_snapshots/test_skill_progress_summary_response_snapshot/skill_progress_summary_response.json
+++ b/life_dashboard/skills/tests/snapshots/test_api_snapshots/test_skill_progress_summary_response_snapshot/skill_progress_summary_response.json
@@ -30,13 +30,13 @@
       {
         "current_level": 28,
         "next_milestone": 30,
-        "progress_percentage": 11.467013225288586,
+        "progress_percentage": 13.760415870346304,
         "skill_name": "JavaScript Development"
       },
       {
         "current_level": 35,
         "next_milestone": 40,
-        "progress_percentage": 4.7086521483225425,
+        "progress_percentage": 9.809691975671964,
         "skill_name": "Python Programming"
       },
       {
@@ -53,16 +53,6 @@
       }
     ],
     "stagnant_skills": [
-      {
-        "days_since_practice": 45,
-        "level": 35,
-        "name": "Python Programming"
-      },
-      {
-        "days_since_practice": 45,
-        "level": 28,
-        "name": "JavaScript Development"
-      },
       {
         "days_since_practice": 45,
         "level": 12,
@@ -101,7 +91,7 @@
         "rank": "Developing"
       }
     ],
-    "total_experience": 34743624,
+    "total_experience": 34745224,
     "total_skills": 5
   },
   "summary_generated_at": "2024-01-15T18:00:00",


### PR DESCRIPTION
## Summary
- update the skills dashboard snapshot to reflect the refined progress metrics and stagnant skill list
- drop the highest potential reward field from the achievements snapshot to mirror the current API payload

## Testing
- `make test-snapshots` *(fails: pytest_snapshot dependency is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cfebdd3e0c8323ad4ae55fee9b3b07