### PR TITLE
[achievements] Stabilize achievement stats snapshot test

### DIFF
--- a/life_dashboard/achievements/tests/test_api_snapshots.py
+++ b/life_dashboard/achievements/tests/test_api_snapshots.py
@@ -26,13 +26,12 @@ from life_dashboard.achievements.domain.value_objects import (
     AchievementIcon,
     AchievementId,
     AchievementName,
-    ExperienceReward,
     RequiredLevel,
     RequiredQuestCompletions,
     RequiredSkillLevel,
     UserAchievementId,
-    UserId,
 )
+from life_dashboard.common.value_objects import ExperienceReward, UserId
 from tests.snapshot_utils import assert_json_snapshot
 
 
@@ -184,6 +183,7 @@ class TestAchievementAPISnapshots:
         # Snapshot the response structure
         assert_json_snapshot(snapshot, api_response, "unlock_achievement_response.json")
 
+    @freeze_time("2024-01-25 18:00:00", tz_offset=0)
     def test_achievement_statistics_response_snapshot(self, snapshot):
         """Test achievement statistics API response structure"""
         # Mock diverse achievements


### PR DESCRIPTION
## Summary
- freeze time within the achievement statistics snapshot test to avoid datetime drift
- correct ExperienceReward and UserId imports to use the shared common value objects module

## Testing
- pytest life_dashboard/achievements/tests/test_api_snapshots.py -k statistics

------
https://chatgpt.com/codex/tasks/task_e_68cff8a27c30832386e327f19182336b