### PR TITLE
[dashboard] Harden profile updates and redis connectivity check

### DIFF
--- a/life_dashboard/dashboard/domain/entities.py
+++ b/life_dashboard/dashboard/domain/entities.py
@@ -73,11 +73,16 @@ class UserProfile:
             "birth_date",
         }
 
+        invalid_fields = sorted(set(kwargs) - allowed_fields)
+        if invalid_fields:
+            field_list = ", ".join(invalid_fields)
+            field_label = "Field" if len(invalid_fields) == 1 else "Fields"
+            verb = "is" if len(invalid_fields) == 1 else "are"
+            raise ValueError(f"{field_label} '{field_list}' {verb} not allowed to be updated")
+
         for field, value in kwargs.items():
             if field in allowed_fields:
                 setattr(self, field, value)
-            else:
-                raise ValueError(f"Field '{field}' is not allowed to be updated")
 
     @property
     def full_name(self) -> str:

--- a/life_dashboard/dashboard/infrastructure/repositories.py
+++ b/life_dashboard/dashboard/infrastructure/repositories.py
@@ -200,13 +200,20 @@ class DjangoUserRepository(UserRepository):
                 last_name=last_name,
             )
 
-            # Get the profile created by the signal and update it with our data
-            django_profile = DjangoUserProfile.objects.get(user=user)
+            # Ensure a profile exists even if the signal failed to create it
+            django_profile, _created = DjangoUserProfile.objects.get_or_create(
+                user=user,
+                defaults={
+                    "bio": bio,
+                    "location": location,
+                },
+            )
+
             django_profile.bio = bio
             django_profile.location = location
             # Keep the auto-generated created_at, but update updated_at
             django_profile.updated_at = timezone.now()
-            django_profile.save()
+            django_profile.save(update_fields=["bio", "location", "updated_at"])
 
             # Convert to domain entity
             domain_profile = DomainUserProfile(


### PR DESCRIPTION
## Summary
- validate dashboard profile updates before mutating state so invalid fields fail atomically
- align privacy retention expiry checks with timezone awareness to avoid naive/aware comparisons
- ensure redis connectivity validation uses short timeouts, closes clients, and repository creation backfills missing profiles

## Testing
- pytest *(fails: known celery fallback fixture expectations and quest chain sanitization constraints)*

------
https://chatgpt.com/codex/tasks/task_e_68cff9a9f3688323ac041b52e69eea82