### PR TITLE
[achievements] enforce skill validation and idempotent saves

### DIFF
--- a/life_dashboard/achievements/domain/services.py
+++ b/life_dashboard/achievements/domain/services.py
@@ -72,7 +72,9 @@ class AchievementService:
         exp_reward = ExperienceReward(experience_reward, max_value=50000)
         req_level = RequiredLevel(required_level)
         req_skill_level = (
-            RequiredSkillLevel(required_skill_level) if required_skill_level else None
+            RequiredSkillLevel(required_skill_level)
+            if required_skill_level is not None
+            else None
         )
         req_quest_completions = RequiredQuestCompletions(required_quest_completions)
 

--- a/life_dashboard/achievements/infrastructure/repositories.py
+++ b/life_dashboard/achievements/infrastructure/repositories.py
@@ -1,0 +1,158 @@
+"""Django-backed repository implementations for achievements domain."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from datetime import timedelta
+from typing import Any
+
+from django.db import IntegrityError, transaction
+from django.utils import timezone
+
+from life_dashboard.achievements.domain.entities import AchievementTier
+from life_dashboard.achievements.domain.entities import (
+    UserAchievement as DomainUserAchievement,
+)
+from life_dashboard.achievements.domain.repositories import UserAchievementRepository
+from life_dashboard.achievements.domain.value_objects import (
+    AchievementId,
+    UserAchievementId,
+)
+from life_dashboard.achievements.models import UserAchievement as DjangoUserAchievement
+from life_dashboard.common.value_objects import UserId
+
+
+class DjangoUserAchievementRepository(UserAchievementRepository):
+    """Persistence adapter for :class:`UserAchievement` entities."""
+
+    def save(self, user_achievement: DomainUserAchievement) -> DomainUserAchievement:
+        """Persist a user achievement, handling duplicate unlocks safely."""
+
+        user_id = self._coerce_user_id(user_achievement.user_id)
+        achievement_id = self._coerce_achievement_id(user_achievement.achievement_id)
+
+        with transaction.atomic():
+            try:
+                with transaction.atomic():
+                    django_user_achievement = DjangoUserAchievement.objects.create(
+                        user_id=user_id,
+                        achievement_id=achievement_id,
+                        notes=user_achievement.notes,
+                        unlocked_at=user_achievement.unlocked_at,
+                    )
+            except IntegrityError:
+                existing = (
+                    DjangoUserAchievement.objects.select_related("achievement")
+                    .get(user_id=user_id, achievement_id=achievement_id)
+                )
+                return self._map_to_domain(
+                    existing, unlock_context=user_achievement.unlock_context
+                )
+
+        return self._map_to_domain(
+            django_user_achievement, unlock_context=user_achievement.unlock_context
+        )
+
+    def get_by_id(
+        self, user_achievement_id: UserAchievementId
+    ) -> DomainUserAchievement | None:
+        try:
+            django_user_achievement = DjangoUserAchievement.objects.get(
+                id=self._coerce_user_achievement_id(user_achievement_id)
+            )
+        except DjangoUserAchievement.DoesNotExist:
+            return None
+
+        return self._map_to_domain(django_user_achievement)
+
+    def get_user_achievements(self, user_id: UserId) -> list[DomainUserAchievement]:
+        queryset = DjangoUserAchievement.objects.filter(
+            user_id=self._coerce_user_id(user_id)
+        ).order_by("-unlocked_at")
+        return [self._map_to_domain(item) for item in queryset]
+
+    def get_user_achievements_by_tier(
+        self, user_id: UserId, tier: AchievementTier
+    ) -> list[DomainUserAchievement]:
+        queryset = DjangoUserAchievement.objects.filter(
+            user_id=self._coerce_user_id(user_id),
+            achievement__tier=self._coerce_tier(tier),
+        ).order_by("-unlocked_at")
+        return [self._map_to_domain(item) for item in queryset]
+
+    def get_recent_achievements(
+        self, user_id: UserId, days: int = 7
+    ) -> list[DomainUserAchievement]:
+        cutoff = timezone.now() - timedelta(days=days)
+        queryset = DjangoUserAchievement.objects.filter(
+            user_id=self._coerce_user_id(user_id),
+            unlocked_at__gte=cutoff,
+        ).order_by("-unlocked_at")
+        return [self._map_to_domain(item) for item in queryset]
+
+    def has_achievement(self, user_id: UserId, achievement_id: AchievementId) -> bool:
+        return DjangoUserAchievement.objects.filter(
+            user_id=self._coerce_user_id(user_id),
+            achievement_id=self._coerce_achievement_id(achievement_id),
+        ).exists()
+
+    def get_achievement_count(self, user_id: UserId) -> int:
+        return DjangoUserAchievement.objects.filter(
+            user_id=self._coerce_user_id(user_id)
+        ).count()
+
+    def delete(self, user_achievement_id: UserAchievementId) -> bool:
+        deleted, _ = DjangoUserAchievement.objects.filter(
+            id=self._coerce_user_achievement_id(user_achievement_id)
+        ).delete()
+        return deleted > 0
+
+    @staticmethod
+    def _map_to_domain(
+        django_user_achievement: DjangoUserAchievement,
+        *,
+        unlock_context: dict[str, Any] | None = None,
+    ) -> DomainUserAchievement:
+        context = deepcopy(unlock_context) if unlock_context else {}
+        return DomainUserAchievement(
+            user_id=UserId(django_user_achievement.user_id),
+            achievement_id=AchievementId(django_user_achievement.achievement_id),
+            unlocked_at=django_user_achievement.unlocked_at,
+            notes=django_user_achievement.notes,
+            unlock_context=context,
+            user_achievement_id=UserAchievementId(django_user_achievement.id)
+            if django_user_achievement.id
+            else None,
+        )
+
+    @staticmethod
+    def _coerce_user_id(user_id: UserId | int | str) -> int:
+        if isinstance(user_id, UserId):
+            return user_id.value
+        if isinstance(user_id, str):
+            return int(user_id)
+        return int(user_id)
+
+    @staticmethod
+    def _coerce_achievement_id(achievement_id: AchievementId | int | str) -> int:
+        if isinstance(achievement_id, AchievementId):
+            return achievement_id.value
+        if isinstance(achievement_id, str):
+            return int(achievement_id)
+        return int(achievement_id)
+
+    @staticmethod
+    def _coerce_user_achievement_id(
+        user_achievement_id: UserAchievementId | int | str,
+    ) -> int:
+        if isinstance(user_achievement_id, UserAchievementId):
+            return user_achievement_id.value
+        if isinstance(user_achievement_id, str):
+            return int(user_achievement_id)
+        return int(user_achievement_id)
+
+    @staticmethod
+    def _coerce_tier(tier: AchievementTier | str) -> str:
+        if isinstance(tier, AchievementTier):
+            return tier.value
+        return str(tier).upper()

--- a/life_dashboard/achievements/tests/test_infrastructure_repositories.py
+++ b/life_dashboard/achievements/tests/test_infrastructure_repositories.py
@@ -1,0 +1,76 @@
+"""Integration tests for achievements infrastructure repositories."""
+
+from datetime import datetime, timezone
+
+import pytest
+from django.contrib.auth import get_user_model
+
+from life_dashboard.achievements.domain.entities import (
+    UserAchievement as DomainUserAchievement,
+)
+from life_dashboard.achievements.domain.value_objects import AchievementId
+from life_dashboard.achievements.infrastructure.repositories import (
+    DjangoUserAchievementRepository,
+)
+from life_dashboard.achievements.models import (
+    Achievement,
+    AchievementTierChoices,
+)
+from life_dashboard.achievements.models import (
+    UserAchievement as DjangoUserAchievement,
+)
+from life_dashboard.common.value_objects import UserId
+
+pytestmark = pytest.mark.django_db
+
+
+def _create_user(username: str = "test-user"):
+    User = get_user_model()
+    return User.objects.create_user(
+        username=username,
+        email=f"{username}@example.com",
+        password="secure-pass-123",
+    )
+
+
+def _create_achievement(name: str = "Test Achievement"):
+    return Achievement.objects.create(
+        name=name,
+        description="Test achievement description",
+        tier=AchievementTierChoices.BRONZE,
+        icon="trophy",
+        experience_reward=100,
+        required_level=1,
+        required_quest_completions=1,
+    )
+
+
+def test_user_achievement_repository_save_returns_existing_on_duplicate_unlock():
+    """Concurrent duplicate unlock attempts should be idempotent."""
+
+    user = _create_user()
+    achievement = _create_achievement()
+    repository = DjangoUserAchievementRepository()
+
+    first_unlock = DomainUserAchievement(
+        user_id=UserId(user.id),
+        achievement_id=AchievementId(achievement.id),
+        unlocked_at=datetime.now(timezone.utc),
+        notes="First unlock",
+    )
+
+    saved_first = repository.save(first_unlock)
+
+    duplicate_unlock = DomainUserAchievement(
+        user_id=UserId(user.id),
+        achievement_id=AchievementId(achievement.id),
+        unlocked_at=datetime.now(timezone.utc),
+        notes="Duplicate attempt",
+    )
+
+    saved_duplicate = repository.save(duplicate_unlock)
+
+    assert saved_first.user_achievement_id is not None
+    assert saved_duplicate.user_achievement_id == saved_first.user_achievement_id
+    assert saved_duplicate.notes == saved_first.notes
+    assert DjangoUserAchievement.objects.count() == 1


### PR DESCRIPTION
## Summary
- ensure RequiredSkillLevel is constructed for zero values instead of skipping validation
- add a Django-backed user achievement repository that returns the existing record when unique constraints fire
- cover the duplicate unlock path with an infrastructure-level test

## Testing
- pytest life_dashboard/achievements/tests/test_infrastructure_repositories.py
- pytest life_dashboard/achievements/tests
- ruff check life_dashboard/achievements/infrastructure/repositories.py life_dashboard/achievements/tests/test_infrastructure_repositories.py

------
https://chatgpt.com/codex/tasks/task_e_68cffbf34ee48323b1dae4af64930eab