### PR TITLE
[tests] Align shared kernel imports and validation errors

### DIFF
--- a/life_dashboard/achievements/tests/test_domain_properties.py
+++ b/life_dashboard/achievements/tests/test_domain_properties.py
@@ -25,13 +25,12 @@ from life_dashboard.achievements.domain.value_objects import (
     AchievementIcon,
     AchievementId,
     AchievementName,
-    ExperienceReward,
     RequiredLevel,
     RequiredQuestCompletions,
     RequiredSkillLevel,
     UserAchievementId,
-    UserId,
 )
+from life_dashboard.common.value_objects import ExperienceReward, UserId
 
 
 # Custom strategies for domain objects

--- a/life_dashboard/achievements/tests/test_service_contracts.py
+++ b/life_dashboard/achievements/tests/test_service_contracts.py
@@ -25,12 +25,11 @@ from life_dashboard.achievements.domain.value_objects import (
     AchievementIcon,
     AchievementId,
     AchievementName,
-    ExperienceReward,
     RequiredLevel,
     RequiredQuestCompletions,
     UserAchievementId,
-    UserId,
 )
+from life_dashboard.common.value_objects import ExperienceReward, UserId
 
 
 # Pydantic models for API contracts

--- a/life_dashboard/journals/tests/test_service_contracts.py
+++ b/life_dashboard/journals/tests/test_service_contracts.py
@@ -7,7 +7,7 @@ from datetime import datetime
 import pytest
 
 pytest.importorskip("pydantic")
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
 from life_dashboard.journals.domain.entities import EntryType, JournalEntry
 from life_dashboard.journals.domain.repositories import JournalEntryRepository
@@ -158,11 +158,11 @@ class TestJournalServiceContracts:
         assert valid_request.mood == 7
 
         # Invalid request - missing title
-        with pytest.raises(ValueError):
+        with pytest.raises(ValidationError):
             CreateEntryRequest(user_id=1, title="", content="Test content")
 
         # Invalid request - invalid mood
-        with pytest.raises(ValueError):
+        with pytest.raises(ValidationError):
             CreateEntryRequest(
                 user_id=1, title="Test Entry", content="Test content", mood=11
             )
@@ -179,7 +179,7 @@ class TestJournalServiceContracts:
         assert valid_request.mood == 5
 
         # Invalid request - empty entry_id
-        with pytest.raises(ValueError):
+        with pytest.raises(ValidationError):
             UpdateEntryRequest(entry_id="", title="Updated Title")
 
     def test_journal_service_create_returns_valid_response(self):


### PR DESCRIPTION
## Summary
- update achievement contract and property tests to pull ExperienceReward and UserId from the shared kernel value objects module
- adjust journal service contract tests to expect `pydantic.ValidationError` for invalid payloads and import the correct exception class

## Testing
- pytest life_dashboard/achievements/tests/test_service_contracts.py life_dashboard/achievements/tests/test_domain_properties.py life_dashboard/journals/tests/test_service_contracts.py

------
https://chatgpt.com/codex/tasks/task_e_68d000f806bc8323887de031d421b574