### PR TITLE
[ci] Install dev dependencies for CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -262,8 +262,8 @@ reset: clean resetdb
 
 # CI/CD helpers
 ci-install:
-	pip install import-linter mypy django-stubs ruff
-	pip install django pydantic
+	pip install -r requirements.txt
+	pip install -e ".[dev]"
 
 ci-check: lint type-check-strict check-architecture
 	@echo "✅ CI checks passed"


### PR DESCRIPTION
## Summary
- ensure the `ci-install` make target installs the pinned runtime requirements
- install the project's development extras so contract tests have their dependencies

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d0016847c88323bcd47d043fb672e9