### PR TITLE
[quests] Switch to timezone aware timestamps

### DIFF
--- a/life_dashboard/journals/domain/entities.py
+++ b/life_dashboard/journals/domain/entities.py
@@ -3,7 +3,7 @@ Journals domain entities - pure Python business logic without Django dependencie
 """
 
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timezone
 from enum import Enum
 from typing import Any
 from uuid import uuid4
@@ -66,7 +66,7 @@ class JournalEntry:
         """
         self.title = title
         self.content = content
-        self.updated_at = datetime.utcnow()
+        self.updated_at = datetime.now(timezone.utc)
 
     def add_tag(self, tag: str) -> None:
         """
@@ -76,7 +76,7 @@ class JournalEntry:
         """
         if tag and tag not in self.tags:
             self.tags.append(tag)
-            self.updated_at = datetime.utcnow()
+            self.updated_at = datetime.now(timezone.utc)
 
     def remove_tag(self, tag: str) -> None:
         """
@@ -87,7 +87,7 @@ class JournalEntry:
         """
         if tag in self.tags:
             self.tags.remove(tag)
-            self.updated_at = datetime.utcnow()
+            self.updated_at = datetime.now(timezone.utc)
 
     def set_mood(self, mood: int) -> None:
         """
@@ -103,7 +103,7 @@ class JournalEntry:
             raise ValueError("Mood rating must be between 1 and 10")
 
         self.mood = mood
-        self.updated_at = datetime.utcnow()
+        self.updated_at = datetime.now(timezone.utc)
 
     def to_dict(self) -> dict[str, Any]:
         """

--- a/life_dashboard/journals/domain/services.py
+++ b/life_dashboard/journals/domain/services.py
@@ -2,7 +2,7 @@
 Journals domain services - business logic orchestration.
 """
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from .entities import EntryType, JournalEntry
 from .repositories import JournalEntryRepository
@@ -53,8 +53,8 @@ class JournalService:
             tags=validated_tags,
             related_quest_id=related_quest_id,
             related_achievement_id=related_achievement_id,
-            created_at=datetime.utcnow(),
-            updated_at=datetime.utcnow(),
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
         )
 
         return self.repository.save(entry)
@@ -94,7 +94,7 @@ class JournalService:
                 validated_tags.append(tag_vo.normalized())
             entry.tags = validated_tags
 
-        entry.updated_at = datetime.utcnow()
+        entry.updated_at = datetime.now(timezone.utc)
         return self.repository.save(entry)
 
     def get_user_entries(self, user_id: int) -> list[JournalEntry]:
@@ -135,7 +135,7 @@ class JournalService:
     def get_mood_statistics(self, user_id: int, days: int = 30) -> dict:
         """Get mood statistics for a user over the last N days."""
         user_id_vo = UserId(user_id)
-        end_date = datetime.utcnow()
+        end_date = datetime.now(timezone.utc)
         start_date = end_date - timedelta(days=days)
 
         entries = self.repository.get_by_user_and_date_range(

--- a/life_dashboard/journals/tests/test_domain_entities.py
+++ b/life_dashboard/journals/tests/test_domain_entities.py
@@ -2,7 +2,7 @@
 Domain entity tests for journals - pure Python business logic tests.
 """
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import pytest
 
@@ -23,8 +23,8 @@ class TestJournalEntry:
             entry_type=EntryType.DAILY,
             mood=8,
             tags=["productivity", "goals"],
-            created_at=datetime.utcnow(),
-            updated_at=datetime.utcnow(),
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
         )
 
         assert entry.user_id == 1
@@ -62,7 +62,7 @@ class TestJournalEntry:
             user_id=1,
             title="Original Title",
             content="Original content",
-            updated_at=datetime.utcnow() - timedelta(hours=1),
+            updated_at=datetime.now(timezone.utc) - timedelta(hours=1),
         )
 
         original_updated_at = entry.updated_at
@@ -80,7 +80,7 @@ class TestJournalEntry:
             title="Test Entry",
             content="Content",
             tags=["existing"],
-            updated_at=datetime.utcnow() - timedelta(hours=1),
+            updated_at=datetime.now(timezone.utc) - timedelta(hours=1),
         )
 
         original_updated_at = entry.updated_at
@@ -106,7 +106,7 @@ class TestJournalEntry:
             title="Test Entry",
             content="Content",
             tags=["tag1", "tag2", "tag3"],
-            updated_at=datetime.utcnow() - timedelta(hours=1),
+            updated_at=datetime.now(timezone.utc) - timedelta(hours=1),
         )
 
         original_updated_at = entry.updated_at
@@ -128,7 +128,7 @@ class TestJournalEntry:
             user_id=1,
             title="Test Entry",
             content="Content",
-            updated_at=datetime.utcnow() - timedelta(hours=1),
+            updated_at=datetime.now(timezone.utc) - timedelta(hours=1),
         )
 
         original_updated_at = entry.updated_at
@@ -147,8 +147,8 @@ class TestJournalEntry:
 
     def test_journal_entry_to_dict(self):
         """Test converting journal entry to dictionary."""
-        created_at = datetime.utcnow()
-        updated_at = datetime.utcnow()
+        created_at = datetime.now(timezone.utc)
+        updated_at = datetime.now(timezone.utc)
 
         entry = JournalEntry(
             entry_id="test-id",

--- a/life_dashboard/journals/tests/test_domain_properties.py
+++ b/life_dashboard/journals/tests/test_domain_properties.py
@@ -2,7 +2,7 @@
 Property-based tests for journals domain - using Hypothesis for comprehensive validation.
 """
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import pytest
 
@@ -94,7 +94,7 @@ class TestJournalEntryProperties:
             user_id=1,
             title="Original Title",
             content="Original content",
-            updated_at=datetime.utcnow() - timedelta(hours=1),
+            updated_at=datetime.now(timezone.utc) - timedelta(hours=1),
         )
 
         original_updated_at = entry.updated_at

--- a/life_dashboard/privacy/application/services.py
+++ b/life_dashboard/privacy/application/services.py
@@ -2,7 +2,7 @@
 Privacy application services - use case orchestration for privacy and consent management.
 """
 
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any
 
 from ..domain.entities import (
@@ -500,7 +500,7 @@ class DataSubjectService:
         """
         export_data = {
             "user_id": user_id,
-            "export_timestamp": datetime.utcnow().isoformat(),
+            "export_timestamp": datetime.now(timezone.utc).isoformat(),
             "data_categories": [cat.value for cat in data_categories],
             "data": {},
         }

--- a/life_dashboard/privacy/domain/value_objects.py
+++ b/life_dashboard/privacy/domain/value_objects.py
@@ -3,7 +3,7 @@ Privacy domain value objects - immutable privacy-related concepts.
 """
 
 from dataclasses import dataclass
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from enum import Enum
 
 
@@ -95,12 +95,12 @@ class DataRetentionPolicy:
         if not self.auto_delete:
             return False
 
+        if created_at.tzinfo is None:
+            created_at = created_at.replace(tzinfo=timezone.utc)
+
         expiry_date = created_at + timedelta(days=self.retention_days)
 
-        if created_at.tzinfo is not None:
-            now = datetime.now(created_at.tzinfo)
-        else:
-            now = datetime.utcnow()
+        now = datetime.now(created_at.tzinfo)
 
         return now > expiry_date
 

--- a/life_dashboard/quests/application/services.py
+++ b/life_dashboard/quests/application/services.py
@@ -2,7 +2,7 @@
 Quests application services - use case orchestration and business workflows.
 """
 
-from datetime import date, datetime
+from datetime import date, datetime, timezone
 from typing import Any
 from uuid import uuid4
 
@@ -161,8 +161,8 @@ class QuestService:
             status=QuestStatus.DRAFT,  # New quests start as draft
             experience_reward=quest_experience,
             due_date=due_date,
-            created_at=datetime.utcnow(),
-            updated_at=datetime.utcnow(),
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
         )
         return self.quest_repo.create(quest)
 
@@ -244,7 +244,7 @@ class QuestService:
         # provided value directly and update the timestamp so repositories can store the
         # change if they support a progress attribute.
         quest.progress = percentage
-        quest.updated_at = datetime.utcnow()
+        quest.updated_at = datetime.now(timezone.utc)
         return self.quest_repo.save(quest)
 
     def pause_quest(self, quest_id: str) -> Quest:
@@ -507,8 +507,8 @@ class HabitService:
             current_streak=StreakCount(0),
             longest_streak=StreakCount(0),
             experience_reward=habit_experience,
-            created_at=datetime.utcnow(),
-            updated_at=datetime.utcnow(),
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
         )
 
         return self.habit_repo.create(habit)
@@ -599,7 +599,7 @@ class HabitService:
             notes=notes,
             experience_gained=completion_experience,
             streak_at_completion=streak_value,
-            created_at=datetime.utcnow(),
+            created_at=datetime.now(timezone.utc),
         )
 
         saved_completion = self.completion_repo.create(completion)
@@ -883,7 +883,7 @@ class QuestChainService:
 
             progress_value = sanitized.pop("progress", None)
             progress_amount = progress_value if progress_value is not None else 0.0
-            timestamp = datetime.utcnow()
+            timestamp = datetime.now(timezone.utc)
 
             prerequisite_values = sanitized.pop("prerequisite_quest_ids", None)
             prerequisite_ids = (

--- a/life_dashboard/quests/domain/entities.py
+++ b/life_dashboard/quests/domain/entities.py
@@ -6,7 +6,7 @@ No Django dependencies allowed in this module.
 """
 
 from dataclasses import dataclass, field
-from datetime import date, datetime
+from datetime import date, datetime, timezone
 from enum import Enum
 from uuid import uuid4
 
@@ -84,8 +84,12 @@ class Quest:
     start_date: date | None = None
     due_date: date | None = None
     completed_at: datetime | None = None
-    created_at: datetime = field(default_factory=datetime.utcnow)
-    updated_at: datetime = field(default_factory=datetime.utcnow)
+    created_at: datetime = field(
+        default_factory=lambda: datetime.now(timezone.utc)
+    )
+    updated_at: datetime = field(
+        default_factory=lambda: datetime.now(timezone.utc)
+    )
 
     def __post_init__(self):
         """Validate quest data after initialization"""
@@ -151,7 +155,7 @@ class Quest:
         self.status = QuestStatus.ACTIVE
         if not self.start_date:
             self.start_date = date.today()
-        self.updated_at = datetime.utcnow()
+        self.updated_at = datetime.now(timezone.utc)
 
     def complete(self) -> None:
         """Complete the quest"""
@@ -159,8 +163,8 @@ class Quest:
             raise ValueError(f"Cannot complete quest from {self.status.value} status")
 
         self.status = QuestStatus.COMPLETED
-        self.completed_at = datetime.utcnow()
-        self.updated_at = datetime.utcnow()
+        self.completed_at = datetime.now(timezone.utc)
+        self.updated_at = datetime.now(timezone.utc)
 
     def fail(self) -> None:
         """Mark quest as failed"""
@@ -168,7 +172,7 @@ class Quest:
             raise ValueError(f"Cannot fail quest from {self.status.value} status")
 
         self.status = QuestStatus.FAILED
-        self.updated_at = datetime.utcnow()
+        self.updated_at = datetime.now(timezone.utc)
 
     def pause(self) -> None:
         """Pause the quest"""
@@ -178,7 +182,7 @@ class Quest:
             raise ValueError(f"Cannot pause quest from {self.status.value} status")
 
         self.status = QuestStatus.PAUSED
-        self.updated_at = datetime.utcnow()
+        self.updated_at = datetime.now(timezone.utc)
 
     def get_difficulty_multiplier(self) -> float:
         """Get experience multiplier based on difficulty"""
@@ -223,8 +227,12 @@ class Habit:
     longest_streak: StreakCount
     experience_reward: ExperienceReward
     habit_id: HabitId | None = None
-    created_at: datetime = field(default_factory=datetime.utcnow)
-    updated_at: datetime = field(default_factory=datetime.utcnow)
+    created_at: datetime = field(
+        default_factory=lambda: datetime.now(timezone.utc)
+    )
+    updated_at: datetime = field(
+        default_factory=lambda: datetime.now(timezone.utc)
+    )
 
     def __post_init__(self):
         """Validate habit data after initialization"""
@@ -265,7 +273,7 @@ class Habit:
         milestone = self.get_streak_milestone_type()
 
         # Ensure timestamps reflect the completion action
-        self.updated_at = datetime.utcnow()
+        self.updated_at = datetime.now(timezone.utc)
 
         return experience_gained, self.current_streak, milestone
 
@@ -300,7 +308,7 @@ class Habit:
                 # Streak broken, reset to 1
                 self.current_streak = StreakCount(1)
 
-        self.updated_at = datetime.utcnow()
+        self.updated_at = datetime.now(timezone.utc)
 
     def _is_consecutive_completion(self, days_diff: int) -> bool:
         """Check if completion maintains streak based on frequency"""
@@ -316,7 +324,7 @@ class Habit:
     def break_streak(self) -> None:
         """Break the current streak"""
         self.current_streak = StreakCount(0)
-        self.updated_at = datetime.utcnow()
+        self.updated_at = datetime.now(timezone.utc)
 
     def get_streak_milestone_type(self) -> str | None:
         """Get milestone type if current streak hits a milestone"""
@@ -346,7 +354,9 @@ class HabitCompletion:
     experience_gained: ExperienceReward
     user_id: UserId | None = None
     streak_at_completion: StreakCount | None = None
-    created_at: datetime = field(default_factory=datetime.utcnow)
+    created_at: datetime = field(
+        default_factory=lambda: datetime.now(timezone.utc)
+    )
 
     def __post_init__(self):
         """Generate completion ID if not provided"""

--- a/life_dashboard/quests/domain/services.py
+++ b/life_dashboard/quests/domain/services.py
@@ -5,7 +5,7 @@ Pure business logic services for quest and habit operations.
 No Django dependencies allowed in this module.
 """
 
-from datetime import date, datetime, timedelta
+from datetime import date, datetime, timedelta, timezone
 
 from .entities import Habit, HabitCompletion, Quest, QuestStatus, QuestType
 from .repositories import HabitCompletionRepository, HabitRepository, QuestRepository
@@ -100,7 +100,7 @@ class QuestService:
         all_quests = self._quest_repository.get_by_user_id(user_id)
 
         # Filter quests from the last N days
-        cutoff_date = datetime.utcnow().date() - timedelta(days=days)
+        cutoff_date = datetime.now(timezone.utc).date() - timedelta(days=days)
         recent_quests = [
             quest for quest in all_quests if quest.created_at.date() >= cutoff_date
         ]

--- a/life_dashboard/quests/tests/test_domain_entities.py
+++ b/life_dashboard/quests/tests/test_domain_entities.py
@@ -4,7 +4,7 @@ Fast unit tests for Quest domain entities.
 These tests run without Django and focus on pure business logic validation.
 """
 
-from datetime import date, datetime, timedelta
+from datetime import date, datetime, timedelta, timezone
 
 import pytest
 
@@ -81,7 +81,7 @@ class TestQuest:
                 quest_type=QuestType.MAIN,
                 status=QuestStatus.ACTIVE,
                 experience_reward=ExperienceReward(50),
-                completed_at=datetime.utcnow(),
+                completed_at=datetime.now(timezone.utc),
             )
 
     def test_daily_quest_cannot_be_paused(self):
@@ -197,7 +197,7 @@ class TestQuest:
             status=QuestStatus.COMPLETED,
             experience_reward=ExperienceReward(50),
             due_date=date.today() - timedelta(days=1),
-            completed_at=datetime.utcnow(),
+            completed_at=datetime.now(timezone.utc),
         )
 
         assert not quest.is_overdue()

--- a/life_dashboard/quests/tests/test_quest_chain_service.py
+++ b/life_dashboard/quests/tests/test_quest_chain_service.py
@@ -1,6 +1,6 @@
 """Tests for QuestChainService child quest creation sanitization."""
 
-from datetime import date, datetime
+from datetime import date, datetime, timezone
 from unittest.mock import MagicMock
 
 import pytest
@@ -28,12 +28,18 @@ class TestQuestChainService:
     ) -> None:
         """Quest data is sanitized and normalized before persistence."""
 
-        fixed_now = datetime(2024, 1, 1, 12, 0, 0)
+        fixed_now = datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
 
         class FixedDateTime(datetime):
             @classmethod
             def utcnow(cls):  # pragma: no cover - trivial override
                 return fixed_now
+
+            @classmethod
+            def now(cls, tz=None):  # pragma: no cover - trivial override
+                if tz is None:
+                    return fixed_now
+                return fixed_now.astimezone(tz)
 
         monkeypatch.setattr(
             "life_dashboard.quests.application.services.datetime",

--- a/life_dashboard/quests/tests/test_service_contracts.py
+++ b/life_dashboard/quests/tests/test_service_contracts.py
@@ -4,7 +4,7 @@ Contract tests for Quest domain services using Pydantic models.
 These tests validate service layer APIs and ensure consistent interfaces.
 """
 
-from datetime import date, datetime
+from datetime import date, datetime, timezone
 from unittest.mock import Mock
 
 import pytest
@@ -338,7 +338,7 @@ class TestQuestServiceContracts:
             quest_type=QuestType.MAIN,
             status=QuestStatus.COMPLETED,
             experience_reward=ExperienceReward(100),
-            completed_at=datetime.utcnow(),
+            completed_at=datetime.now(timezone.utc),
         )
 
         self.mock_repository.get_by_id.return_value = mock_quest

--- a/life_dashboard/shared/README.md
+++ b/life_dashboard/shared/README.md
@@ -62,6 +62,8 @@ The domain event system provides a lightweight, type-safe, and version-compatibl
 
 ### Basic Event Publishing
 ```python
+from datetime import datetime, timezone
+
 from shared.domain.events import QuestCompleted
 from shared.domain.event_dispatcher import publish_event
 
@@ -71,7 +73,7 @@ event = QuestCompleted(
     quest_id=456,
     quest_type="daily",
     experience_reward=25,
-    completion_timestamp=datetime.utcnow(),
+    completion_timestamp=datetime.now(timezone.utc),
     auto_completed=False
 )
 

--- a/life_dashboard/shared/examples/event_system_demo.py
+++ b/life_dashboard/shared/examples/event_system_demo.py
@@ -7,7 +7,7 @@ with event handlers, version compatibility, and privacy-aware processing.
 
 import os
 import sys
-from datetime import datetime
+from datetime import datetime, timezone
 
 # Add the parent directory to the path so we can import from shared
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -51,7 +51,7 @@ def check_achievements_on_quest_completion(event: QuestCompleted):
             achievement_name="Daily Warrior",
             tier="bronze",
             experience_reward=50,
-            unlock_timestamp=datetime.utcnow(),
+            unlock_timestamp=datetime.now(timezone.utc),
         )
         publish_event(achievement_event)
 
@@ -92,7 +92,7 @@ def demo_event_system():
         quest_id=456,
         quest_type="daily",
         experience_reward=25,
-        completion_timestamp=datetime.utcnow(),
+        completion_timestamp=datetime.now(timezone.utc),
         auto_completed=False,
     )
 

--- a/life_dashboard/shared/tests/test_domain_events.py
+++ b/life_dashboard/shared/tests/test_domain_events.py
@@ -6,7 +6,7 @@ and all canonical events from the domain events catalog.
 """
 
 import json
-from datetime import datetime
+from datetime import datetime, timezone
 
 from life_dashboard.shared.domain.events import (
     AchievementProgressUpdated,
@@ -181,7 +181,7 @@ class TestCanonicalEvents:
         event = UserRegistered(
             user_id=123,
             email="test@example.com",
-            registration_timestamp=datetime.utcnow(),
+            registration_timestamp=datetime.now(timezone.utc),
         )
 
         assert event.user_id == 123
@@ -236,7 +236,7 @@ class TestCanonicalEvents:
 
     def test_quest_completed_event(self):
         """Test QuestCompleted event schema."""
-        completion_time = datetime.utcnow()
+        completion_time = datetime.now(timezone.utc)
         event = QuestCompleted(
             user_id=123,
             quest_id=456,
@@ -275,7 +275,7 @@ class TestCanonicalEvents:
 
     def test_achievement_unlocked_event(self):
         """Test AchievementUnlocked event schema."""
-        unlock_time = datetime.utcnow()
+        unlock_time = datetime.now(timezone.utc)
         event = AchievementUnlocked(
             user_id=123,
             achievement_id=456,
@@ -316,7 +316,7 @@ class TestCanonicalEvents:
 
     def test_external_data_received_event(self):
         """Test ExternalDataReceived event schema."""
-        sync_time = datetime.utcnow()
+        sync_time = datetime.now(timezone.utc)
         event = ExternalDataReceived(
             user_id=123,
             integration_id=456,
@@ -336,7 +336,7 @@ class TestCanonicalEvents:
 
     def test_balance_score_calculated_event(self):
         """Test BalanceScoreCalculated event schema."""
-        calc_time = datetime.utcnow()
+        calc_time = datetime.now(timezone.utc)
         event = BalanceScoreCalculated(
             user_id=123,
             health_score=0.8,
@@ -356,7 +356,7 @@ class TestCanonicalEvents:
 
     def test_all_events_have_version(self):
         """Test that all canonical events have version field."""
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         events_to_test = [
             # Core Events
             UserRegistered(
@@ -646,7 +646,7 @@ class TestCanonicalEvents:
 
     def test_all_events_serializable(self):
         """Test that all canonical events can be serialized and deserialized."""
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         # Test a representative sample of events (not all to keep test fast)
         events_to_test = [
             UserRegistered(

--- a/life_dashboard/shared/tests/test_event_dispatcher.py
+++ b/life_dashboard/shared/tests/test_event_dispatcher.py
@@ -154,7 +154,7 @@ class TestEventDispatcher:
             quest_id=456,
             quest_type="daily",
             experience_reward=25,
-            completion_timestamp=datetime.utcnow(),
+            completion_timestamp=datetime.now(timezone.utc),
             auto_completed=False,
         )
 
@@ -175,7 +175,7 @@ class TestEventDispatcher:
             quest_id=456,
             quest_type="daily",
             experience_reward=25,
-            completion_timestamp=datetime.utcnow(),
+            completion_timestamp=datetime.now(timezone.utc),
             auto_completed=False,
             version="1.0.0",
         )
@@ -191,7 +191,7 @@ class TestEventDispatcher:
             quest_id=456,
             quest_type="daily",
             experience_reward=25,
-            completion_timestamp=datetime.utcnow(),
+            completion_timestamp=datetime.now(timezone.utc),
             auto_completed=False,
         )
 
@@ -218,7 +218,7 @@ class TestEventDispatcher:
             quest_id=456,
             quest_type="daily",
             experience_reward=25,
-            completion_timestamp=datetime.utcnow(),
+            completion_timestamp=datetime.now(timezone.utc),
             auto_completed=False,
         )
 
@@ -236,7 +236,7 @@ class TestEventDispatcher:
             quest_id=456,
             quest_type="daily",
             experience_reward=25,
-            completion_timestamp=datetime.utcnow(),
+            completion_timestamp=datetime.now(timezone.utc),
             auto_completed=False,
         )
 
@@ -255,7 +255,7 @@ class TestEventDispatcher:
             quest_id=456,
             quest_type="daily",
             experience_reward=25,
-            completion_timestamp=datetime.utcnow(),
+            completion_timestamp=datetime.now(timezone.utc),
             auto_completed=False,
         )
 
@@ -341,7 +341,7 @@ class TestGlobalDispatcher:
             quest_id=456,
             quest_type="daily",
             experience_reward=25,
-            completion_timestamp=datetime.utcnow(),
+            completion_timestamp=datetime.now(timezone.utc),
             auto_completed=False,
         )
 
@@ -436,7 +436,7 @@ class TestPrivacyAwareDispatcher:
             quest_id=456,
             quest_type="daily",
             experience_reward=25,
-            completion_timestamp=datetime.utcnow(),
+            completion_timestamp=datetime.now(timezone.utc),
             auto_completed=False,
         )
 
@@ -463,7 +463,7 @@ class TestPrivacyAwareDispatcher:
             quest_id=456,
             quest_type="daily",
             experience_reward=25,
-            completion_timestamp=datetime.utcnow(),
+            completion_timestamp=datetime.now(timezone.utc),
             auto_completed=False,
         )
 

--- a/life_dashboard/skills/domain/entities.py
+++ b/life_dashboard/skills/domain/entities.py
@@ -6,7 +6,7 @@ No Django dependencies allowed in this module.
 """
 
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timezone
 from enum import Enum
 
 from .value_objects import (
@@ -43,7 +43,9 @@ class SkillCategory:
     name: CategoryName
     description: str
     icon: str = ""
-    created_at: datetime = field(default_factory=datetime.utcnow)
+    created_at: datetime = field(
+        default_factory=lambda: datetime.now(timezone.utc)
+    )
 
     def __post_init__(self):
         """Validate category data after initialization"""
@@ -70,7 +72,9 @@ class Skill:
     level: SkillLevel
     experience_points: ExperiencePoints
     experience_to_next_level: ExperiencePoints
-    created_at: datetime = field(default_factory=datetime.utcnow)
+    created_at: datetime = field(
+        default_factory=lambda: datetime.now(timezone.utc)
+    )
     last_practiced: datetime | None = None
 
     def __post_init__(self):
@@ -188,7 +192,7 @@ class Skill:
                 exp_to_next if current_level < 100 else 0
             ),
             created_at=self.created_at,
-            last_practiced=datetime.utcnow(),
+            last_practiced=datetime.now(timezone.utc),
         )
 
         return updated_skill, levels_gained
@@ -266,7 +270,7 @@ class Skill:
         if not self.last_practiced:
             return True
 
-        reference_time = current_time or datetime.utcnow()
+        reference_time = current_time or datetime.now(timezone.utc)
         days_since_practice = (reference_time - self.last_practiced).days
         return days_since_practice > days_threshold
 

--- a/life_dashboard/skills/domain/services.py
+++ b/life_dashboard/skills/domain/services.py
@@ -5,7 +5,7 @@ Pure business logic services for skills operations.
 No Django dependencies allowed in this module.
 """
 
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, cast
 
 from .entities import Skill, SkillCategory, SkillMasteryLevel
@@ -100,7 +100,9 @@ class SkillService:
         # Calculate days since last practice
         days_since_practice = 0
         if skill.last_practiced:
-            days_since_practice = (datetime.utcnow() - skill.last_practiced).days
+            days_since_practice = (
+                datetime.now(timezone.utc) - skill.last_practiced
+            ).days
 
         # Calculate practice efficiency
         efficiency = skill.calculate_practice_efficiency(days_since_practice)
@@ -167,7 +169,7 @@ class SkillService:
             }
 
         # Use provided time for deterministic calculations when needed
-        reference_time = current_time or datetime.utcnow()
+        reference_time = current_time or datetime.now(timezone.utc)
 
         # Calculate statistics
         total_skills = len(user_skills)

--- a/life_dashboard/skills/tests/test_domain_entities.py
+++ b/life_dashboard/skills/tests/test_domain_entities.py
@@ -4,7 +4,7 @@ Fast unit tests for Skills domain entities.
 These tests run without Django and focus on pure business logic validation.
 """
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import pytest
 
@@ -377,7 +377,7 @@ class TestSkill:
             level=SkillLevel(5),
             experience_points=ExperiencePoints(0),
             experience_to_next_level=ExperiencePoints(1000),
-            last_practiced=datetime.utcnow() - timedelta(days=10),
+            last_practiced=datetime.now(timezone.utc) - timedelta(days=10),
         )
         assert not skill_recent.is_stagnant(30)
 
@@ -391,7 +391,7 @@ class TestSkill:
             level=SkillLevel(5),
             experience_points=ExperiencePoints(0),
             experience_to_next_level=ExperiencePoints(1000),
-            last_practiced=datetime.utcnow() - timedelta(days=45),
+            last_practiced=datetime.now(timezone.utc) - timedelta(days=45),
         )
         assert skill_stagnant.is_stagnant(30)
 


### PR DESCRIPTION
## Summary
- replace naive `datetime.utcnow()` defaults and updates with timezone-aware `datetime.now(timezone.utc)` across quests, journals, skills, privacy, and shared modules
- align retention policy and other domain services to normalize naive timestamps as UTC before comparison
- refresh tests, fixtures, and docs to expect timezone-aware datetimes

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d000d7c4088323baca5bae80a7f473