### PR TITLE
[dashboard] Guard password updates from empty values

### DIFF
--- a/life_dashboard/dashboard/infrastructure/repositories.py
+++ b/life_dashboard/dashboard/infrastructure/repositories.py
@@ -130,8 +130,9 @@ class DjangoUserRepository(UserRepository):
                     continue
 
                 if field == "password":
-                    user.set_password(value)
-                    needs_save = True
+                    if isinstance(value, str) and value.strip():
+                        user.set_password(value)
+                        needs_save = True
                 elif hasattr(user, field):
                     setattr(user, field, value)
                     needs_save = True


### PR DESCRIPTION
## Summary
- prevent the user repository from hashing unusable passwords when update_user receives empty or non-string password values

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d00282261083239957a75f79b8b9a9