### PR TITLE
[stats] Restore legacy aliases

### DIFF
--- a/life_dashboard/stats/models.py
+++ b/life_dashboard/stats/models.py
@@ -9,10 +9,18 @@ from .infrastructure.models import (  # noqa: F401
     Stats,  # Legacy model for backward compatibility
 )
 
+# Legacy aliases to maintain backwards compatibility with previous public API
+CoreStat = CoreStatModel
+LifeStat = LifeStatModel
+StatHistory = StatHistoryModel
+
 __all__ = [
     "CoreStatModel",
     "LifeStatCategoryModel",
     "LifeStatModel",
     "StatHistoryModel",
     "Stats",
+    "CoreStat",
+    "LifeStat",
+    "StatHistory",
 ]


### PR DESCRIPTION
## Summary
- add legacy aliases mapping CoreStat, LifeStat, and StatHistory to the renamed model classes
- include the legacy aliases in the module export list to preserve the public API

## Testing
- pytest life_dashboard/stats -q
- ruff check life_dashboard/stats/models.py
- ruff format life_dashboard/stats/models.py
- mypy --strict life_dashboard/stats/models.py *(fails: existing missing annotations and Django base class typing issues in life_dashboard/stats/infrastructure/models.py)*

------
https://chatgpt.com/codex/tasks/task_e_68d006dff6108323b209e5360842cf40