### PR TITLE
[skills] Add registry for skill discovery

### DIFF
--- a/life_dashboard/skills/__init__.py
+++ b/life_dashboard/skills/__init__.py
@@ -1,1 +1,8 @@
-# This file marks the skills package
+"""Skills package exposing discovery helpers for domain registrations."""
+
+from .registry import register_skill, skill_registry
+
+__all__ = [
+    "register_skill",
+    "skill_registry",
+]

--- a/life_dashboard/skills/domain/entities.py
+++ b/life_dashboard/skills/domain/entities.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from enum import Enum
 
+from ..registry import register_skill
 from .value_objects import (
     CategoryName,
     ExperienceAmount,
@@ -31,6 +32,7 @@ class SkillMasteryLevel(Enum):
     MASTER = "master"  # Levels 81-100
 
 
+@register_skill
 @dataclass
 class SkillCategory:
     """
@@ -53,6 +55,7 @@ class SkillCategory:
             raise ValueError("Category icon cannot exceed 50 characters")
 
 
+@register_skill
 @dataclass
 class Skill:
     """

--- a/life_dashboard/skills/registry.py
+++ b/life_dashboard/skills/registry.py
@@ -1,0 +1,81 @@
+"""Skill registry for discovery and introspection.
+
+The skills context relies on self-registration of skill domain classes so that
+new skills can be discovered without manually wiring them into the package.
+This module provides the lightweight registry that domain entities use to
+register themselves on import.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Iterator, MutableMapping
+from dataclasses import dataclass, field
+from typing import TypeVar
+
+__all__ = [
+    "SkillRegistry",
+    "skill_registry",
+    "register_skill",
+]
+
+
+T = TypeVar("T", bound=type)
+
+
+@dataclass(slots=True)
+class SkillRegistry:
+    """In-memory registry mapping string identifiers to skill classes."""
+
+    _registry: MutableMapping[str, type] = field(default_factory=dict)
+
+    def register(self, skill_cls: type, name: str | None = None) -> type:
+        """Register *skill_cls* under *name* and return the class.
+
+        If *name* is omitted the class name is used. Duplicate registrations for
+        the same identifier are rejected unless they refer to the exact same
+        class.
+        """
+
+        identifier = name or getattr(skill_cls, "slug", None) or skill_cls.__name__
+        if identifier in self._registry and self._registry[identifier] is not skill_cls:
+            existing = self._registry[identifier].__name__
+            raise ValueError(
+                f"Skill '{identifier}' already registered by '{existing}'."
+            )
+
+        self._registry[identifier] = skill_cls
+        return skill_cls
+
+    def get(self, name: str) -> type:
+        """Return the registered skill class for *name*.
+
+        Raises ``KeyError`` if the skill has not been registered.
+        """
+
+        try:
+            return self._registry[name]
+        except KeyError as exc:  # pragma: no cover - defensive branch
+            raise KeyError(f"Skill '{name}' is not registered") from exc
+
+    def __contains__(self, name: str) -> bool:
+        return name in self._registry
+
+    def __iter__(self) -> Iterator[type]:
+        return iter(self._registry.values())
+
+    def items(self) -> Iterable[tuple[str, type]]:
+        return self._registry.items()
+
+    def clear(self) -> None:
+        self._registry.clear()
+
+
+skill_registry = SkillRegistry()
+
+
+def register_skill(skill_cls: T, *, name: str | None = None) -> T:
+    """Decorator to register a skill class when it is defined."""
+
+    skill_registry.register(skill_cls, name=name)
+    return skill_cls
+

--- a/life_dashboard/skills/tests/test_registry.py
+++ b/life_dashboard/skills/tests/test_registry.py
@@ -1,0 +1,34 @@
+"""Tests for the skills registry and automatic discovery."""
+
+import importlib
+
+import pytest
+
+
+def test_domain_entities_are_registered():
+    """Skill domain entities should self-register on import."""
+
+    entities = importlib.import_module("life_dashboard.skills.domain.entities")
+    from life_dashboard.skills import skill_registry
+
+    assert skill_registry.get("SkillCategory") is entities.SkillCategory
+    assert skill_registry.get("Skill") is entities.Skill
+
+
+def test_registry_rejects_conflicting_registrations():
+    """Different classes cannot claim the same registry identifier."""
+
+    from life_dashboard.skills.registry import SkillRegistry
+
+    registry = SkillRegistry()
+
+    class DummySkill:
+        pass
+
+    class AnotherSkill:
+        pass
+
+    registry.register(DummySkill, name="dummy")
+
+    with pytest.raises(ValueError):
+        registry.register(AnotherSkill, name="dummy")


### PR DESCRIPTION
## Summary
- add a lightweight registry for skills and expose it from the package
- ensure domain skill entities self-register using the decorator
- cover registration behaviour with unit tests

## Testing
- pytest life_dashboard/skills/tests/test_registry.py
- ruff check life_dashboard/skills

------
https://chatgpt.com/codex/tasks/task_e_68d00701e228832381d5731f6013320c