### PR TITLE
[dashboard] Guard habit activity serialization

### DIFF
--- a/life_dashboard/life_dashboard/celery.py
+++ b/life_dashboard/life_dashboard/celery.py
@@ -35,7 +35,7 @@ def _create_sync_decorator(
                         if exc is not None:
                             raise exc
 
-                    _TaskSelf.retry = retry
+                    setattr(_TaskSelf, "retry", retry)
 
                 call_args = (task_self, *args)
             else:

--- a/life_dashboard/shared/queries.py
+++ b/life_dashboard/shared/queries.py
@@ -215,15 +215,17 @@ class CrossContextQueries:
                 ).order_by("-date")[:5]
 
                 for completion in recent_habits:
-                    activities.append(
-                        {
-                            "type": "habit_completed",
-                            "title": completion.habit.name,
-                            "timestamp": completion.date,
-                            "experience_gained": completion.experience_gained,
-                            "context": "quests",
-                        }
-                    )
+                    activity = {
+                        "type": "habit_completed",
+                        "title": completion.habit.name,
+                        "timestamp": completion.date,
+                        "context": "quests",
+                    }
+
+                    if hasattr(completion, "experience_gained"):
+                        activity["experience_gained"] = completion.experience_gained
+
+                    activities.append(activity)
 
             # Recent journal entries
             if hasattr(user, "journal_entries"):


### PR DESCRIPTION
## Summary
- only include habit completion experience when the attribute exists to avoid attribute errors in cross-context queries
- update the Celery fallback retry injection to match the expected structure

## Testing
- python manage.py migrate
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d00713753083239f4f8d7441906865