### PR TITLE
[quests] Enforce numeric quest identifiers in repository helper

### DIFF
--- a/life_dashboard/quests/infrastructure/repositories.py
+++ b/life_dashboard/quests/infrastructure/repositories.py
@@ -35,7 +35,15 @@ def _quest_id_as_int(quest_id: QuestId | int | str | None) -> int:
     """Normalize quest identifiers to integers for ORM operations."""
 
     if isinstance(quest_id, QuestId):
-        return quest_id.value
+        raw_value = quest_id.value
+        if isinstance(raw_value, str):
+            raw_value = raw_value.strip()
+            if not raw_value:
+                raise ValueError("Quest ID cannot be blank")
+        try:
+            return int(raw_value)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f"Invalid quest_id: {quest_id.value}") from exc
     if isinstance(quest_id, int):
         return quest_id
     if isinstance(quest_id, str):

--- a/tests/quests/test_infrastructure_repositories.py
+++ b/tests/quests/test_infrastructure_repositories.py
@@ -1,0 +1,34 @@
+import pytest
+
+from life_dashboard.quests.domain.value_objects import QuestId
+from life_dashboard.quests.infrastructure.repositories import _quest_id_as_int
+
+
+class TestQuestIdNormalization:
+    """Tests for quest identifier normalization helper."""
+
+    def test_numeric_quest_id_value_object_returns_int(self):
+        """Numeric quest identifiers wrapped in QuestId should resolve to ints."""
+
+        quest_id = QuestId(42)
+
+        assert _quest_id_as_int(quest_id) == 42
+
+    def test_non_numeric_quest_id_value_object_raises_value_error(self):
+        """QuestId values containing non-numeric text should raise ValueError."""
+
+        quest_id = QuestId("quest-alpha")
+
+        with pytest.raises(ValueError):
+            _quest_id_as_int(quest_id)
+
+    def test_string_with_whitespace_is_trimmed_and_converted(self):
+        """String quest identifiers should be trimmed before conversion."""
+
+        assert _quest_id_as_int("   7  ") == 7
+
+    def test_blank_string_raises_value_error(self):
+        """Blank string quest identifiers should not be accepted."""
+
+        with pytest.raises(ValueError):
+            _quest_id_as_int("   ")


### PR DESCRIPTION
## Summary
- coerce quest repository helper to convert QuestId values to integers and reject non-numeric identifiers
- add regression tests covering quest identifier normalization and trimming logic

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d009332ce48323a71520c7b26b8702