### PR TITLE
[privacy] Harden DSAR read paths

### DIFF
--- a/life_dashboard/privacy/domain/entities.py
+++ b/life_dashboard/privacy/domain/entities.py
@@ -147,6 +147,20 @@ class ConsentRecord:
 
         return True
 
+    def is_valid_readonly(self, *, as_of: datetime | None = None) -> bool:
+        """Return True when the consent remains granted and unexpired without mutating state."""
+
+        if as_of is None:
+            as_of = datetime.now(timezone.utc)
+
+        if self.status != ConsentStatus.GRANTED:
+            return False
+
+        if self.expires_at and as_of > self.expires_at:
+            return False
+
+        return True
+
     def is_expired(self) -> bool:
         """
         Return True if the consent has a configured expiration time that is in the past.

--- a/life_dashboard/privacy/tests/test_privacy_service_read_paths.py
+++ b/life_dashboard/privacy/tests/test_privacy_service_read_paths.py
@@ -1,0 +1,79 @@
+"""Tests covering read-only privacy service behaviour."""
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock
+
+from life_dashboard.privacy.application.services import ConsentService, PrivacyService
+from life_dashboard.privacy.domain.entities import (
+    ConsentRecord,
+    ConsentStatus,
+    DataCategory,
+    DataProcessingPurpose,
+)
+
+
+def test_check_consent_does_not_mutate_expired_record():
+    """Expired consents should remain unchanged when checked for validity."""
+    consent_repo = MagicMock()
+    activity_repo = MagicMock()
+    service = ConsentService(consent_repo, activity_repo)
+
+    expired_consent = ConsentRecord(
+        user_id=1,
+        purpose=DataProcessingPurpose.ANALYTICS,
+        data_categories={DataCategory.BEHAVIORAL},
+        status=ConsentStatus.GRANTED,
+        granted_at=datetime.now(timezone.utc) - timedelta(days=10),
+        expires_at=datetime.now(timezone.utc) - timedelta(days=1),
+    )
+
+    consent_repo.get_by_user_and_purpose.return_value = expired_consent
+
+    result = service.check_consent(1, DataProcessingPurpose.ANALYTICS, DataCategory.BEHAVIORAL)
+
+    assert result is False
+    assert expired_consent.status == ConsentStatus.GRANTED
+
+
+def test_can_process_data_defaults_to_disabled_settings_when_missing():
+    """A missing privacy settings record should not be created during a read path."""
+    settings_repo = MagicMock()
+    activity_repo = MagicMock()
+    consent_service = MagicMock()
+    consent_service.check_consent.return_value = True
+
+    service = PrivacyService(settings_repo, activity_repo, consent_service)
+
+    settings_repo.get_by_user_id.return_value = None
+
+    result = service.can_process_data(
+        user_id=2,
+        purpose=DataProcessingPurpose.ANALYTICS,
+        data_category=DataCategory.BEHAVIORAL,
+    )
+
+    assert result is False
+    settings_repo.get_by_user_id.assert_called_once_with(2)
+    settings_repo.create.assert_not_called()
+
+
+def test_can_process_data_core_functionality_allows_when_consent_present():
+    """Core functionality should remain accessible when consent is granted even without settings."""
+    settings_repo = MagicMock()
+    activity_repo = MagicMock()
+    consent_service = MagicMock()
+    consent_service.check_consent.return_value = True
+
+    service = PrivacyService(settings_repo, activity_repo, consent_service)
+
+    settings_repo.get_by_user_id.return_value = None
+
+    result = service.can_process_data(
+        user_id=3,
+        purpose=DataProcessingPurpose.CORE_FUNCTIONALITY,
+        data_category=DataCategory.BASIC_PROFILE,
+    )
+
+    assert result is True
+    settings_repo.get_by_user_id.assert_called_once_with(3)
+

--- a/life_dashboard/privacy/tests/test_verification_method_fix.py
+++ b/life_dashboard/privacy/tests/test_verification_method_fix.py
@@ -1,13 +1,15 @@
-"""
-Tests for verification method fix in privacy services.
-"""
+"""Tests for data subject service processing safeguards and verification handling."""
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, call
 
 import pytest
 
 from life_dashboard.privacy.application.services import DataSubjectService
-from life_dashboard.privacy.domain.entities import DataCategory, DataSubjectRequest
+from life_dashboard.privacy.domain.entities import (
+    DataCategory,
+    DataProcessingPurpose,
+    DataSubjectRequest,
+)
 
 
 class TestVerificationMethodFix:
@@ -30,6 +32,8 @@ class TestVerificationMethodFix:
         mock_request = MagicMock(spec=DataSubjectRequest)
         mock_request.user_id = 123
         mock_request.data_categories = {DataCategory.BASIC_PROFILE}
+        mock_request.request_id = "req-1"
+        mock_request.status = "pending"
         mock_request.identity_verified = False  # Ensure identity needs verification
 
         self.request_repo.get_by_id.return_value = mock_request
@@ -51,6 +55,8 @@ class TestVerificationMethodFix:
         mock_request = MagicMock(spec=DataSubjectRequest)
         mock_request.user_id = 123
         mock_request.data_categories = {DataCategory.BASIC_PROFILE}
+        mock_request.request_id = "req-2"
+        mock_request.status = "pending"
         mock_request.identity_verified = True
 
         self.request_repo.get_by_id.return_value = mock_request
@@ -68,6 +74,9 @@ class TestVerificationMethodFix:
         # Arrange
         mock_request = MagicMock(spec=DataSubjectRequest)
         mock_request.user_id = 123
+        mock_request.data_categories = set(DataCategory)
+        mock_request.request_id = "req-3"
+        mock_request.status = "pending"
         mock_request.identity_verified = False  # Ensure identity needs verification
 
         self.request_repo.get_by_id.return_value = mock_request
@@ -88,6 +97,10 @@ class TestVerificationMethodFix:
         # Arrange
         mock_request = MagicMock(spec=DataSubjectRequest)
         mock_request.user_id = 123
+        mock_request.data_categories = set(DataCategory)
+        mock_request.request_id = "req-4"
+        mock_request.status = "pending"
+        mock_request.identity_verified = True
 
         self.request_repo.get_by_id.return_value = mock_request
         self.service._delete_user_data = MagicMock(return_value=42)
@@ -98,6 +111,9 @@ class TestVerificationMethodFix:
         # Assert
         mock_request.verify_identity.assert_not_called()
         mock_request.start_processing.assert_called_once_with(789)
+        self.service._delete_user_data.assert_called_once_with(
+            123, delete_activities=False
+        )
 
     def test_method_signatures_have_verification_method_parameter(self):
         """Test that both methods have verification_method parameter with default None."""
@@ -128,3 +144,101 @@ class TestVerificationMethodFix:
             self.service.process_deletion_request(
                 "nonexistent", 123, verification_method="email"
             )
+
+    def test_process_export_request_logs_audit_events(self):
+        """Processing an export request should emit start and completion audit activities."""
+        mock_request = MagicMock(spec=DataSubjectRequest)
+        mock_request.user_id = 7
+        mock_request.data_categories = {DataCategory.BASIC_PROFILE}
+        mock_request.request_id = "export-1"
+        mock_request.status = "pending"
+        mock_request.identity_verified = True
+
+        self.request_repo.get_by_id.return_value = mock_request
+        self.service._collect_user_data = MagicMock(return_value={})
+
+        self.service.process_export_request("export-1", 99)
+
+        activities = [
+            call.args[0] for call in self.activity_repo.log_activity.call_args_list
+        ]
+        assert {activity.processing_type for activity in activities} == {
+            "dsar_export_started",
+            "dsar_export_completed",
+        }
+        for activity in activities:
+            assert activity.context == "data_subject_service:export"
+            assert activity.legal_basis == "legal_obligation"
+            assert activity.purpose == DataProcessingPurpose.CORE_FUNCTIONALITY
+            assert activity.request_id == "export-1"
+
+    def test_process_deletion_request_logs_audit_events(self):
+        """Processing a deletion request should emit start and completion audit activities."""
+        mock_request = MagicMock(spec=DataSubjectRequest)
+        mock_request.user_id = 9
+        mock_request.data_categories = set(DataCategory)
+        mock_request.request_id = "delete-1"
+        mock_request.status = "pending"
+        mock_request.identity_verified = True
+
+        self.request_repo.get_by_id.return_value = mock_request
+        self.service._delete_user_data = MagicMock(return_value=5)
+
+        self.service.process_deletion_request("delete-1", 42)
+
+        activities = [
+            call.args[0] for call in self.activity_repo.log_activity.call_args_list
+        ]
+        assert {activity.processing_type for activity in activities} == {
+            "dsar_deletion_started",
+            "dsar_deletion_completed",
+        }
+        for activity in activities:
+            assert activity.context == "data_subject_service:deletion"
+            assert activity.legal_basis == "legal_obligation"
+            assert activity.purpose == DataProcessingPurpose.CORE_FUNCTIONALITY
+            assert activity.request_id == "delete-1"
+
+    def test_process_export_request_prevents_double_processing(self):
+        """Requests that are already resolved should raise an error when reprocessed."""
+        mock_request = MagicMock(spec=DataSubjectRequest)
+        mock_request.status = "completed"
+
+        self.request_repo.get_by_id.return_value = mock_request
+
+        with pytest.raises(ValueError, match="already been resolved"):
+            self.service.process_export_request("export-2", 1)
+
+    def test_process_deletion_request_prevents_double_processing(self):
+        """Requests already in processing should not be processed again."""
+        mock_request = MagicMock(spec=DataSubjectRequest)
+        mock_request.status = "processing"
+
+        self.request_repo.get_by_id.return_value = mock_request
+
+        with pytest.raises(ValueError, match="already being processed"):
+            self.service.process_deletion_request("delete-2", 1)
+
+    def test_process_deletion_respects_activity_policy_toggle(self):
+        """Deletion should pass the configured activity deletion policy flag."""
+        service = DataSubjectService(
+            self.request_repo,
+            self.settings_repo,
+            self.consent_repo,
+            self.activity_repo,
+            delete_activity_logs_on_deletion=True,
+        )
+
+        mock_request = MagicMock(spec=DataSubjectRequest)
+        mock_request.user_id = 321
+        mock_request.data_categories = set(DataCategory)
+        mock_request.request_id = "delete-flag"
+        mock_request.status = "pending"
+        mock_request.identity_verified = True
+
+        self.request_repo.get_by_id.return_value = mock_request
+        service._delete_user_data = MagicMock(return_value=0)
+
+        service.process_deletion_request("delete-flag", 5)
+
+        service._delete_user_data.assert_called_once_with(321, delete_activities=True)


### PR DESCRIPTION
## Summary
- add a read-only consent validity helper and use it when checking category coverage
- avoid creating privacy settings during authorization lookups
- guard DSAR processing against replays, add audit logging, and gate activity deletion behind a policy flag
- extend privacy test coverage for consent checks, settings defaults, DSAR auditing, and deletion policies

## Testing
- pytest life_dashboard/privacy/tests


------
https://chatgpt.com/codex/tasks/task_e_68d0090b27f0832392108ea7da75d8e8