### PR TITLE
[privacy] Prevent consent serialization from expiring records

### DIFF
--- a/life_dashboard/privacy/domain/entities.py
+++ b/life_dashboard/privacy/domain/entities.py
@@ -217,7 +217,7 @@ class ConsentRecord:
             else None,
             "expires_at": self.expires_at.isoformat() if self.expires_at else None,
             "version": self.version,
-            "is_valid": self.is_valid(),
+            "is_valid": self.is_valid_readonly(),
             "is_expired": self.is_expired(),
         }
 


### PR DESCRIPTION
## Summary
- stop ConsentRecord.to_dict from using the mutating validity check so serialization stays read-only

## Testing
- pytest tests/test_basic.py

------
https://chatgpt.com/codex/tasks/task_e_68d0166b68ac8323930ea76dfc50b3c5