### PR TITLE
[quests] enforce habit repository create contract

### DIFF
--- a/life_dashboard/quests/domain/services.py
+++ b/life_dashboard/quests/domain/services.py
@@ -164,14 +164,15 @@ class HabitService:
             experience_reward=exp_reward,
         )
 
-        created_habit = self._habit_repository.create(habit)
+        created = self._habit_repository.create(habit)
 
-        # Mirror the quest service behaviour so tests that stub save() still
-        # receive the mocked Habit entity.
-        if not isinstance(created_habit, Habit):
-            created_habit = self._habit_repository.save(habit)
+        if not isinstance(created, Habit):
+            raise TypeError(
+                "HabitRepository.create must return Habit, "
+                f"got {type(created).__name__}: {created!r}"
+            )
 
-        return created_habit
+        return created
 
     def complete_habit(
         self,


### PR DESCRIPTION
## Summary
- ensure HabitService does not silently fall back to save() when create() fails
- raise a descriptive TypeError when HabitRepository.create returns an unexpected value

## Testing
- ruff check .
- mypy .
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d01694fd4c83238f1fba98730123ea