### PR TITLE
[quests] Enforce habit repo contract

### DIFF
--- a/life_dashboard/quests/tests/test_api_snapshots.py
+++ b/life_dashboard/quests/tests/test_api_snapshots.py
@@ -275,7 +275,7 @@ class TestHabitAPISnapshots:
             created_at=datetime(2024, 1, 1, 10, 0, 0),
             updated_at=datetime(2024, 1, 1, 10, 0, 0),
         )
-        self.mock_habit_repository.save.return_value = mock_habit
+        self.mock_habit_repository.create.return_value = mock_habit
 
         # Create habit through service
         result = self.habit_service.create_habit(

--- a/life_dashboard/quests/tests/test_service_contracts.py
+++ b/life_dashboard/quests/tests/test_service_contracts.py
@@ -431,7 +431,7 @@ class TestHabitServiceContracts:
             longest_streak=StreakCount(0),
             experience_reward=ExperienceReward(25),
         )
-        self.mock_habit_repository.save.return_value = mock_habit
+        self.mock_habit_repository.create.return_value = mock_habit
 
         # Create habit through service
         result = self.habit_service.create_habit(
@@ -462,6 +462,24 @@ class TestHabitServiceContracts:
         response = HabitResponse(**response_data)
         assert response.habit_id == 1
         assert response.name == "Exercise"
+
+    def test_habit_service_create_raises_for_invalid_repository_response(self):
+        """Habit creation should surface repository contract violations."""
+
+        self.mock_habit_repository.create.return_value = object()
+
+        with pytest.raises(TypeError) as exc_info:
+            self.habit_service.create_habit(
+                user_id=UserId(1),
+                name="Exercise",
+                description="Daily workout routine",
+                frequency="daily",
+                target_count=1,
+                experience_reward=25,
+            )
+
+        assert "HabitRepository must return Habit instances" in str(exc_info.value)
+        self.mock_habit_repository.save.assert_not_called()
 
     def test_complete_habit_returns_valid_completion_response(self):
         """Test that habit completion returns valid response contract"""


### PR DESCRIPTION
## Summary
- guard HabitService.create_habit so the fallback save path only runs when the repository assigned an ID
- update habit contract and snapshot tests to stub HabitRepository.create instead of relying on the fallback
- add a regression test that surfaces contract violations when the repository returns a non-Habit without an ID

## Testing
- pytest life_dashboard/quests/tests/test_service_contracts.py -k HabitService *(skipped: missing optional dependency `pydantic`)*
- pytest life_dashboard/quests/tests/test_api_snapshots.py -k habit_creation *(skipped: missing optional dependency `pytest_snapshot`)*

------
https://chatgpt.com/codex/tasks/task_e_68d0731e884483239e5dfd8772f1ca04