### PR TITLE
[quests] tighten QuestId normalization validation

### DIFF
--- a/life_dashboard/quests/domain/value_objects.py
+++ b/life_dashboard/quests/domain/value_objects.py
@@ -50,18 +50,20 @@ class QuestId:
 
         if isinstance(value, str):
             text_value = value.strip()
-        else:
-            text_value = str(value).strip()
-        if not text_value:
-            raise ValueError("Quest ID cannot be empty")
+            if not text_value:
+                raise ValueError("Quest ID cannot be empty")
 
-        if text_value.isdigit():
-            numeric_value = int(text_value)
-            if numeric_value <= 0:
-                raise ValueError("Quest ID must be positive")
-            return numeric_value
+            if text_value.isdigit():
+                numeric_value = int(text_value)
+                if numeric_value <= 0:
+                    raise ValueError("Quest ID must be positive")
+                return numeric_value
 
-        return text_value
+            return text_value
+
+        raise TypeError(
+            f"Unsupported Quest ID type: {type(value).__name__}"
+        )
 
     def __eq__(self, other: object) -> bool:  # pragma: no cover - simple delegation
         if isinstance(other, QuestId):


### PR DESCRIPTION
## Summary
- tighten QuestId normalization to only accept integers greater than zero and trimmed strings
- raise errors for unsupported quest identifier types instead of coercing arbitrary objects

## Testing
- pytest tests/quests/test_infrastructure_repositories.py

------
https://chatgpt.com/codex/tasks/task_e_68d0758b04b88323a31f9eb08bf34ed6