### PR TITLE
[privacy] Guard data subject processing by request type

### DIFF
--- a/life_dashboard/privacy/application/services.py
+++ b/life_dashboard/privacy/application/services.py
@@ -425,6 +425,9 @@ class DataSubjectService:
         if not request:
             raise ValueError(f"Request {request_id} not found")
 
+        if getattr(request, "request_type", None) != "export":
+            raise ValueError(f"Request {request_id} is not an export request")
+
         if request.status in {"completed", "rejected"}:
             raise ValueError(
                 f"Request {request_id} has already been resolved with status {request.status}"
@@ -514,6 +517,9 @@ class DataSubjectService:
             raise ValueError(
                 f"Request {request_id} is already being processed and cannot be processed twice"
             )
+
+        if getattr(request, "request_type", None) not in {"delete", "deletion"}:
+            raise ValueError(f"Request {request_id} is not a deletion request")
 
         # Ensure identity is verified before processing
         if not request.identity_verified:


### PR DESCRIPTION
## Summary
- add explicit request_type guard before export processing to ensure only export requests proceed
- validate deletion processing only runs for deletion-type requests and log helpful errors otherwise
- update privacy service tests to set request_type expectations and cover mismatched request types

## Testing
- pytest life_dashboard/privacy/tests/test_verification_method_fix.py
- ruff check .
- mypy . *(fails: existing repository typing errors outside modified code)*

------
https://chatgpt.com/codex/tasks/task_e_68d0755f5c608323af9bec3e1828ee82