### PR TITLE
[quests] Harden quest and habit service invariants

### DIFF
--- a/life_dashboard/quests/domain/entities.py
+++ b/life_dashboard/quests/domain/entities.py
@@ -348,6 +348,31 @@ class HabitCompletion:
     streak_at_completion: StreakCount | None = None
     created_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
 
+    @classmethod
+    def create(
+        cls,
+        *,
+        habit_id: HabitId,
+        count: CompletionCount,
+        completion_date: date,
+        notes: str,
+        experience_gained: ExperienceReward,
+        user_id: UserId | None = None,
+        streak_at_completion: StreakCount | None = None,
+    ) -> "HabitCompletion":
+        """Factory method to build a completion with generated identifier."""
+
+        return cls(
+            completion_id="",
+            habit_id=habit_id,
+            count=count,
+            completion_date=completion_date,
+            notes=notes,
+            experience_gained=experience_gained,
+            user_id=user_id,
+            streak_at_completion=streak_at_completion,
+        )
+
     def __post_init__(self):
         """Generate completion ID if not provided"""
         if not self.completion_id:


### PR DESCRIPTION
## Summary
- ensure quest creation uses the shared `ExperienceReward` value object import and enforces that repositories return `Quest`
- add a `HabitCompletion.create` factory and persist completions with user and streak metadata
- update habit consistency calculations to account for completion counts and habit target counts

## Testing
- pytest tests/quests
- ruff check life_dashboard/quests/domain/entities.py life_dashboard/quests/domain/services.py

------
https://chatgpt.com/codex/tasks/task_e_68d0772f28b88323a00863d2ccc8e860