### PR TITLE
[privacy] Guard DSAR processing and add failure audits

### DIFF
--- a/life_dashboard/privacy/domain/entities.py
+++ b/life_dashboard/privacy/domain/entities.py
@@ -5,6 +5,7 @@ Privacy domain entities - pure Python privacy and consent management logic.
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from enum import Enum
+from typing import Any
 from uuid import uuid4
 
 
@@ -241,6 +242,7 @@ class DataProcessingActivity:
     # Legal basis
     legal_basis: str = "consent"  # consent, legitimate_interest, contract, etc.
     consent_id: str | None = None
+    details: dict[str, Any] | None = None
 
     def __post_init__(self):
         """
@@ -275,6 +277,7 @@ class DataProcessingActivity:
             "session_id": self.session_id,
             "legal_basis": self.legal_basis,
             "consent_id": self.consent_id,
+            "details": self.details,
         }
 
 

--- a/life_dashboard/privacy/domain/repositories.py
+++ b/life_dashboard/privacy/domain/repositories.py
@@ -303,6 +303,25 @@ class DataSubjectRequestRepository(ABC):
         pass
 
     @abstractmethod
+    def mark_processing_if_pending(
+        self, request_id: str, processor_id: int
+    ) -> DataSubjectRequest | None:
+        """Atomically transition a pending request into processing and return it.
+
+        Attempt to set the request identified by `request_id` to status "processing"
+        while recording the `processor_id`. The transition must occur atomically in
+        the persistence layer so that only a single worker can claim the request. If
+        the request is no longer pending, the method returns None without modifying
+        state.
+
+        Returns:
+            Optional[DataSubjectRequest]: The updated request marked as processing when
+            the transition succeeds; otherwise None when another processor has already
+            claimed or resolved the request.
+        """
+        pass
+
+    @abstractmethod
     def get_pending_requests(self) -> list[DataSubjectRequest]:
         """Get all pending requests."""
         pass


### PR DESCRIPTION
## Summary
- add an atomic `mark_processing_if_pending` repository contract and update DSAR export/deletion flows to use it
- reject and audit DSAR export/deletion failures with detailed failure activities while preserving success behaviour
- extend `DataProcessingActivity` with optional `details` metadata and expand privacy service tests for the new flow

## Testing
- pytest life_dashboard/privacy/tests/test_verification_method_fix.py

------
https://chatgpt.com/codex/tasks/task_e_68d078b4a940832388183a3d7c138c99