### PR TITLE
[quests] tighten quest id normalization

### DIFF
--- a/life_dashboard/quests/domain/value_objects.py
+++ b/life_dashboard/quests/domain/value_objects.py
@@ -53,13 +53,14 @@ class QuestId:
             if not text_value:
                 raise ValueError("Quest ID cannot be empty")
 
-            if text_value.isdigit():
+            try:
                 numeric_value = int(text_value)
-                if numeric_value <= 0:
-                    raise ValueError("Quest ID must be positive")
-                return numeric_value
+            except ValueError:
+                return text_value
 
-            return text_value
+            if numeric_value <= 0:
+                raise ValueError("Quest ID must be positive")
+            return numeric_value
 
         raise TypeError(f"Unsupported Quest ID type: {type(value).__name__}")
 

--- a/tests/quests/test_domain_value_objects.py
+++ b/tests/quests/test_domain_value_objects.py
@@ -1,0 +1,32 @@
+"""Tests for quest domain value objects."""
+
+import pytest
+
+from life_dashboard.quests.domain.value_objects import QuestId
+
+
+def test_quest_id_rejects_boolean_values() -> None:
+    with pytest.raises(ValueError):
+        QuestId(True)
+
+
+def test_quest_id_rejects_none_values() -> None:
+    with pytest.raises(TypeError):
+        QuestId(None)
+
+
+def test_quest_id_rejects_negative_numeric_string() -> None:
+    with pytest.raises(ValueError):
+        QuestId(" -10 ")
+
+
+def test_quest_id_accepts_trimmed_string_identifier() -> None:
+    quest_id = QuestId("  quest-abc  ")
+
+    assert quest_id.value == "quest-abc"
+
+
+def test_quest_id_converts_positive_numeric_string_to_int() -> None:
+    quest_id = QuestId(" 42 ")
+
+    assert quest_id.value == 42


### PR DESCRIPTION
## Summary
- restrict `QuestId` normalization to positive ints and trimmed non-empty strings, rejecting unsupported types
- add tests covering invalid booleans, `None`, and numeric string edge cases

## Testing
- pytest tests/quests/test_domain_value_objects.py

------
https://chatgpt.com/codex/tasks/task_e_68d07b4262f88323891b87dfe23ca701