### PR TITLE
BLA-5 - [staticfiles] Prevent removing wrong item in SelectBox cache

### DIFF
--- a/staticfiles/admin/js/SelectBox.js
+++ b/staticfiles/admin/js/SelectBox.js
@@ -46,7 +46,7 @@
             return cache.filter(node => node.displayed === 0).length;
         },
         delete_from_cache: function(id, value) {
-            let delete_index = null;
+            let delete_index = -1;
             const cache = SelectBox.cache[id];
             for (const [i, node] of cache.entries()) {
                 if (node.value === value) {
@@ -54,7 +54,9 @@
                     break;
                 }
             }
-            cache.splice(delete_index, 1);
+            if (delete_index !== -1) {
+                cache.splice(delete_index, 1);
+            }
         },
         add_to_cache: function(id, option) {
             SelectBox.cache[id].push({value: option.value, text: option.text, displayed: 1});


### PR DESCRIPTION
## Summary
- guard SelectBox.delete_from_cache from removing entries when the value does not exist
- initialize the delete index to -1 to detect missing cache entries

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d0880932908323804c8289f7f5afff