### PR TITLE
BLA-6 - [dashboard] Guard Unicode slug generation without XRegExp

### DIFF
--- a/staticfiles/admin/js/urlify.js
+++ b/staticfiles/admin/js/urlify.js
@@ -153,6 +153,10 @@
         }
         s = s.toLowerCase(); // convert to lowercase
         // if downcode doesn't hit, the char will be stripped here
+        if (allowUnicode && typeof XRegExp === 'undefined') {
+            // Fallback to ASCII-only path if XRegExp is unavailable.
+            allowUnicode = false;
+        }
         if (allowUnicode) {
             // Keep Unicode letters including both lowercase and uppercase
             // characters, whitespace, and dash; remove other characters.


### PR DESCRIPTION
## Summary
- prevent Unicode slug handling from throwing when XRegExp is unavailable by falling back to ASCII mode

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d08819edd08323a4afd7db1909bf21