### PR TITLE
BLA-9, BLA-11 - [dashboard] Support reset database alias

### DIFF
--- a/life_dashboard/dashboard/management/commands/resetdb.py
+++ b/life_dashboard/dashboard/management/commands/resetdb.py
@@ -25,7 +25,7 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args, **options):
-        database = options["database"]
+        db_alias = options["database"]
         noinput = options["noinput"]
         auto_confirm = (
             noinput
@@ -59,7 +59,7 @@ class Command(BaseCommand):
         self.stdout.write("Resetting the database...")
 
         try:
-            reset_database(database=database)
+            reset_database(db_alias=db_alias)
             self.stdout.write(self.style.SUCCESS("Database reset successfully!"))
         except RuntimeError as exc:
             message = str(exc)

--- a/life_dashboard/dashboard/utils/__init__.py
+++ b/life_dashboard/dashboard/utils/__init__.py
@@ -19,7 +19,7 @@ def _sqlite_foreign_keys_disabled(connection):
         cursor.close()
 
 
-def reset_database(*, database: str = DEFAULT_DB_ALIAS) -> None:
+def reset_database(*, db_alias: str = DEFAULT_DB_ALIAS) -> None:
     """Safely reset the configured database.
 
     The reset operation is only permitted when DEBUG is enabled and the
@@ -36,8 +36,8 @@ def reset_database(*, database: str = DEFAULT_DB_ALIAS) -> None:
     if environment in {"production", "prod", "staging"}:
         raise RuntimeError("Database reset is blocked in production-like environments.")
 
-    connection = connections[database]
-    flush_kwargs = {"database": database, "interactive": False, "verbosity": 0}
+    connection = connections[db_alias]
+    flush_kwargs = {"database": db_alias, "interactive": False, "verbosity": 0}
 
     if connection.vendor == "sqlite":
         with _sqlite_foreign_keys_disabled(connection):
@@ -45,4 +45,4 @@ def reset_database(*, database: str = DEFAULT_DB_ALIAS) -> None:
     else:
         call_command("flush", **flush_kwargs)
 
-    call_command("migrate", database=database, interactive=False, verbosity=0)
+    call_command("migrate", database=db_alias, interactive=False, verbosity=0)


### PR DESCRIPTION
## Summary
- allow `reset_database` utility to target a specific database alias
- update management command to forward alias argument to the utility

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d08851d6788323838545215442ca55