### PR TITLE
BLA-12 - [dashboard] Prevent prepopulate from overriding manual edits

### DIFF
--- a/staticfiles/admin/js/prepopulate.js
+++ b/staticfiles/admin/js/prepopulate.js
@@ -31,7 +31,7 @@
             };
 
             prepopulatedField.data('_changed', false);
-            prepopulatedField.on('change', function() {
+            prepopulatedField.on('input keyup', function() {
                 prepopulatedField.data('_changed', true);
             });
 


### PR DESCRIPTION
## Summary
- mark prepopulated fields as changed on input/keyup events so manual edits are preserved immediately

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d0887957b0832382f1cb5f7f191a83