### PR TITLE
[shared] Implement shared kernel abstractions

### DIFF
--- a/life_dashboard/shared/domain/__init__.py
+++ b/life_dashboard/shared/domain/__init__.py
@@ -1,1 +1,27 @@
-# Shared domain layer for cross-context domain objects
+"""Shared kernel exports for cross-context domain primitives."""
+
+from .event_dispatcher import EventDispatcher, EventHandler, handles, publish_event
+from .events import BaseEvent
+from .exceptions import DomainError, RepositoryError, TransactionError, ValidationError
+from .model import Entity, ValueObject
+from .repository import AbstractRepository, InMemoryRepository, RepositoryProtocol
+from .unit_of_work import AbstractUnitOfWork, InMemoryUnitOfWork
+
+__all__ = [
+    "AbstractRepository",
+    "AbstractUnitOfWork",
+    "BaseEvent",
+    "DomainError",
+    "Entity",
+    "EventDispatcher",
+    "EventHandler",
+    "InMemoryRepository",
+    "InMemoryUnitOfWork",
+    "RepositoryError",
+    "RepositoryProtocol",
+    "TransactionError",
+    "ValidationError",
+    "ValueObject",
+    "handles",
+    "publish_event",
+]

--- a/life_dashboard/shared/domain/exceptions.py
+++ b/life_dashboard/shared/domain/exceptions.py
@@ -1,0 +1,19 @@
+"""Shared domain-layer exception hierarchy."""
+
+from __future__ import annotations
+
+
+class DomainError(Exception):
+    """Base class for domain-specific errors in the shared kernel."""
+
+
+class ValidationError(DomainError):
+    """Raised when value objects fail validation rules."""
+
+
+class RepositoryError(DomainError):
+    """Raised for repository contract or persistence violations."""
+
+
+class TransactionError(DomainError):
+    """Raised when unit of work or transaction boundaries are violated."""

--- a/life_dashboard/shared/domain/model.py
+++ b/life_dashboard/shared/domain/model.py
@@ -1,0 +1,130 @@
+"""Shared kernel base abstractions for entities and value objects."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from collections.abc import Mapping, Sequence
+from dataclasses import fields, is_dataclass
+from typing import Any, Generic, TypeVar
+
+from .events import BaseEvent
+from .exceptions import ValidationError
+
+_IdentifierT = TypeVar("_IdentifierT")
+
+
+class Entity(ABC, Generic[_IdentifierT]):
+    """Base class for aggregate roots and entities."""
+
+    def __init__(self, entity_id: _IdentifierT | None = None) -> None:
+        self.id = entity_id
+        self._domain_events: list[BaseEvent] = []
+
+    def __eq__(self, other: object) -> bool:  # pragma: no cover - trivial
+        if self is other:
+            return True
+
+        if not isinstance(other, Entity):
+            return False
+
+        if self.id is not None and other.id is not None:
+            return self.id == other.id and type(self) is type(other)
+
+        return type(self) is type(other) and self._identity_map() == other._identity_map()
+
+    def __hash__(self) -> int:  # pragma: no cover - trivial
+        if self.id is not None:
+            return hash((type(self), self.id))
+        return hash((type(self), tuple(sorted(self._identity_map().items()))))
+
+    def _identity_map(self) -> dict[str, Any]:
+        """Return a deterministic mapping of identity attributes for comparisons."""
+
+        return {
+            key: value
+            for key, value in self.__dict__.items()
+            if not key.startswith("_")
+        }
+
+    def record_event(self, event: BaseEvent) -> None:
+        """Attach a domain event that occurred on this entity."""
+
+        if not isinstance(event, BaseEvent):
+            raise TypeError("Entities can only record BaseEvent instances")
+        self._domain_events.append(event)
+
+    def pull_events(self) -> list[BaseEvent]:
+        """Return and clear all currently registered domain events."""
+
+        events = list(self._domain_events)
+        self._domain_events.clear()
+        return events
+
+    def collect_events(self) -> list[BaseEvent]:
+        """Return a copy of currently registered domain events without clearing them."""
+
+        return list(self._domain_events)
+
+    def clear_events(self) -> None:
+        """Remove all currently registered domain events."""
+
+        self._domain_events.clear()
+
+
+class ValueObject(ABC):
+    """Base class for immutable value objects with validation support."""
+
+    def __post_init__(self) -> None:
+        self.validate()
+
+    @abstractmethod
+    def _validate(self) -> None:
+        """Validation hook executed after initialization."""
+
+        # Subclasses should override. Raising ensures mistakes are surfaced early.
+        raise NotImplementedError("Value objects must implement _validate().")
+
+    def validate(self) -> None:
+        """Public validation entry point for re-validation in tests."""
+
+        try:
+            self._validate()
+        except ValidationError:
+            raise
+        except NotImplementedError:
+            raise
+        except Exception as exc:  # pragma: no cover - defensive programming
+            raise ValidationError(str(exc)) from exc
+
+    def __eq__(self, other: object) -> bool:  # pragma: no cover - trivial
+        if type(self) is not type(other):
+            return False
+        return self._frozen_state() == other._frozen_state()
+
+    def __hash__(self) -> int:  # pragma: no cover - trivial
+        return hash((type(self), self._frozen_state()))
+
+    def _frozen_state(self) -> tuple[Any, ...]:
+        """Return an immutable representation of the value object's state."""
+
+        values: list[Any] = []
+
+        if is_dataclass(self):
+            for field in fields(self):
+                values.append(self._freeze(getattr(self, field.name)))
+        else:
+            for key in sorted(self.__dict__):
+                values.append(self._freeze(getattr(self, key)))
+
+        return tuple(values)
+
+    def _freeze(self, value: Any) -> Any:
+        """Recursively convert mutable containers into hashable representations."""
+
+        if isinstance(value, Mapping):
+            return tuple((key, self._freeze(val)) for key, val in sorted(value.items()))
+
+        if isinstance(value, Sequence) and not isinstance(value, str | bytes | bytearray):
+            return tuple(self._freeze(item) for item in value)
+
+        return value

--- a/life_dashboard/shared/domain/repository.py
+++ b/life_dashboard/shared/domain/repository.py
@@ -1,0 +1,106 @@
+"""Shared kernel repository contracts and implementations."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from collections.abc import Iterable, Sequence
+from typing import Any, Generic, Protocol, TypeVar, runtime_checkable
+
+from .exceptions import RepositoryError
+from .model import Entity
+
+_EntityT = TypeVar("_EntityT", bound=Entity[Any])
+_IdentifierT = TypeVar("_IdentifierT")
+
+
+@runtime_checkable
+class RepositoryProtocol(Protocol[_EntityT, _IdentifierT]):
+    """Structural typing contract for repository implementations."""
+
+    def get_by_id(self, entity_id: _IdentifierT) -> _EntityT | None: ...
+
+    def save(self, entity: _EntityT) -> _EntityT: ...
+
+    def delete(self, entity_id: _IdentifierT) -> bool: ...
+
+    def list(self) -> Sequence[_EntityT]: ...
+
+
+class AbstractRepository(ABC, Generic[_EntityT, _IdentifierT]):
+    """Base repository enforcing contract semantics and type safety."""
+
+    def __init__(self) -> None:
+        self._seen: set[_EntityT] = set()
+
+    def get_by_id(self, entity_id: _IdentifierT) -> _EntityT | None:
+        entity = self._get_by_id(entity_id)
+        if entity is not None:
+            self._seen.add(entity)
+        return entity
+
+    def save(self, entity: _EntityT) -> _EntityT:
+        self._ensure_identifier(entity)
+        persisted = self._save(entity)
+        self._seen.add(persisted)
+        return persisted
+
+    def delete(self, entity_id: _IdentifierT) -> bool:
+        return self._delete(entity_id)
+
+    def list(self) -> Sequence[_EntityT]:
+        return list(self._list())
+
+    @abstractmethod
+    def _get_by_id(self, entity_id: _IdentifierT) -> _EntityT | None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def _save(self, entity: _EntityT) -> _EntityT:
+        raise NotImplementedError
+
+    @abstractmethod
+    def _delete(self, entity_id: _IdentifierT) -> bool:
+        raise NotImplementedError
+
+    @abstractmethod
+    def _list(self) -> Iterable[_EntityT]:
+        raise NotImplementedError
+
+    def _ensure_identifier(self, entity: _EntityT) -> None:
+        entity_id = getattr(entity, "id", None)
+        if entity_id is None:
+            raise RepositoryError("Entities must define an identifier before saving.")
+
+
+class InMemoryRepository(AbstractRepository[_EntityT, _IdentifierT], RepositoryProtocol[_EntityT, _IdentifierT]):
+    """Generic in-memory repository for testing and prototypes."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._store: dict[_IdentifierT, _EntityT] = {}
+
+    def _get_by_id(self, entity_id: _IdentifierT) -> _EntityT | None:
+        return self._store.get(entity_id)
+
+    def _save(self, entity: _EntityT) -> _EntityT:
+        identifier = getattr(entity, "id", None)
+        if identifier is None:
+            raise RepositoryError("Entities must define an identifier before saving.")
+        self._store[identifier] = entity
+        return entity
+
+    def _delete(self, entity_id: _IdentifierT) -> bool:
+        return self._store.pop(entity_id, None) is not None
+
+    def _list(self) -> Iterable[_EntityT]:
+        return tuple(self._store.values())
+
+    def exists(self, entity_id: _IdentifierT) -> bool:
+        """Check if an entity exists in the repository."""
+
+        return entity_id in self._store
+
+    def clear(self) -> None:
+        """Remove all entities from the repository."""
+
+        self._store.clear()

--- a/life_dashboard/shared/domain/unit_of_work.py
+++ b/life_dashboard/shared/domain/unit_of_work.py
@@ -1,0 +1,139 @@
+"""Shared kernel Unit of Work abstractions."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from collections.abc import Callable
+from contextlib import AbstractContextManager
+from typing import Self, TypeVar
+
+from .exceptions import TransactionError
+
+_ReturnT = TypeVar("_ReturnT")
+
+
+class AbstractUnitOfWork(AbstractContextManager[Self], ABC):
+    """Base Unit of Work coordinating transactional boundaries."""
+
+    def __init__(self) -> None:
+        self._is_active = False
+        self._pending_operations: list[Callable[[], None]] = []
+        self._committed = False
+        self._rolled_back = False
+
+    def __enter__(self) -> Self:
+        if self._is_active:
+            raise TransactionError("Unit of work already active.")
+        self._is_active = True
+        self._committed = False
+        self._rolled_back = False
+        self._on_enter()
+        return self
+
+    def __exit__(self, exc_type, exc, traceback) -> bool:
+        try:
+            if exc_type:
+                self.rollback()
+            else:
+                try:
+                    self.commit()
+                except Exception:  # pragma: no cover - defensive
+                    self.rollback()
+                    raise
+        finally:
+            self._on_exit()
+            self._is_active = False
+            self._pending_operations.clear()
+        return False
+
+    def _on_enter(self) -> None:
+        """Hook for subclasses when a transaction begins."""
+
+    def _on_exit(self) -> None:
+        """Hook for subclasses when a transaction ends."""
+
+    @property
+    def committed(self) -> bool:
+        """Indicate whether the unit of work successfully committed."""
+
+        return self._committed
+
+    @property
+    def rolled_back(self) -> bool:
+        """Indicate whether the unit of work rolled back a transaction."""
+
+        return self._rolled_back
+
+    def register_operation(self, operation: Callable[[], None]) -> None:
+        """Register a callable to execute when the transaction commits."""
+
+        if not self._is_active:
+            raise TransactionError("Operations require an active transaction.")
+        if not callable(operation):
+            raise TransactionError("Registered operations must be callable.")
+        self._pending_operations.append(operation)
+
+    def commit(self) -> None:
+        """Execute pending operations and finalize the transaction."""
+
+        if not self._is_active:
+            raise TransactionError("Cannot commit outside an active transaction.")
+
+        try:
+            for operation in list(self._pending_operations):
+                operation()
+        except Exception as exc:
+            raise TransactionError("Transaction operation failed.") from exc
+
+        self._commit()
+        self._pending_operations.clear()
+        self._committed = True
+
+    def rollback(self) -> None:
+        """Rollback the transaction and discard pending operations."""
+
+        if not self._is_active:
+            raise TransactionError("Cannot rollback outside an active transaction.")
+
+        self._pending_operations.clear()
+        self._rollback()
+        self._rolled_back = True
+
+    def run_atomic(self, operation: Callable[[Self], _ReturnT]) -> _ReturnT:
+        """Execute an operation within a managed transaction."""
+
+        if self._is_active:
+            raise TransactionError("Cannot nest transactions on the same unit of work.")
+
+        self.__enter__()
+        try:
+            result = operation(self)
+        except Exception as exc:
+            self.__exit__(type(exc), exc, exc.__traceback__)
+            raise
+        else:
+            self.__exit__(None, None, None)
+            return result
+
+    @abstractmethod
+    def _commit(self) -> None:
+        """Persist changes to the underlying persistence mechanism."""
+
+    @abstractmethod
+    def _rollback(self) -> None:
+        """Rollback changes in the underlying persistence mechanism."""
+
+
+class InMemoryUnitOfWork(AbstractUnitOfWork):
+    """Simple in-memory unit of work used for testing."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.commit_calls = 0
+        self.rollback_calls = 0
+
+    def _commit(self) -> None:
+        self.commit_calls += 1
+
+    def _rollback(self) -> None:
+        self.rollback_calls += 1

--- a/life_dashboard/shared/tests/test_domain_model.py
+++ b/life_dashboard/shared/tests/test_domain_model.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+
+import pytest
+
+from life_dashboard.shared.domain.events import BaseEvent
+from life_dashboard.shared.domain.exceptions import ValidationError
+from life_dashboard.shared.domain.model import Entity, ValueObject
+
+
+class _SampleEvent(BaseEvent):
+    def __init__(self, payload: str) -> None:
+        super().__init__()
+        self.payload = payload
+
+
+class _SampleEntity(Entity[int]):
+    def __init__(self, entity_id: int | None, name: str) -> None:
+        super().__init__(entity_id)
+        self.name = name
+        self.created_at = datetime(2024, 1, 1, tzinfo=timezone.utc)
+
+
+@dataclass(frozen=True)
+class _PositiveAmount(ValueObject):
+    amount: int
+
+    def _validate(self) -> None:
+        if self.amount <= 0:
+            raise ValidationError("amount must be positive")
+
+
+def test_entities_with_same_identifier_are_equal() -> None:
+    left = _SampleEntity(1, "Alpha")
+    right = _SampleEntity(1, "Alpha")
+
+    assert left == right
+    assert hash(left) == hash(right)
+
+
+def test_entities_without_identifier_compare_by_state() -> None:
+    left = _SampleEntity(None, "Alpha")
+    right = _SampleEntity(None, "Alpha")
+
+    assert left == right
+
+
+def test_entity_domain_events_are_tracked_and_cleared() -> None:
+    entity = _SampleEntity(1, "Alpha")
+    event = _SampleEvent("payload")
+
+    entity.record_event(event)
+
+    assert entity.collect_events() == [event]
+
+    pulled = entity.pull_events()
+    assert pulled == [event]
+    assert entity.collect_events() == []
+
+
+def test_value_object_validation_runs_during_initialisation() -> None:
+    with pytest.raises(ValidationError):
+        _PositiveAmount(0)
+
+    value = _PositiveAmount(5)
+    value.validate()
+
+
+def test_value_object_equality_depends_on_all_fields() -> None:
+    assert _PositiveAmount(5) == _PositiveAmount(5)
+    assert _PositiveAmount(5) != _PositiveAmount(6)

--- a/life_dashboard/shared/tests/test_repository.py
+++ b/life_dashboard/shared/tests/test_repository.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import pytest
+
+from life_dashboard.shared.domain.exceptions import RepositoryError
+from life_dashboard.shared.domain.model import Entity
+from life_dashboard.shared.domain.repository import (
+    InMemoryRepository,
+    RepositoryProtocol,
+)
+
+
+class _TrackedEntity(Entity[int]):
+    def __init__(self, entity_id: int | None, name: str) -> None:
+        super().__init__(entity_id)
+        self.id = entity_id
+        self.name = name
+
+
+def test_in_memory_repository_roundtrip() -> None:
+    repository: InMemoryRepository[_TrackedEntity, int] = InMemoryRepository()
+    entity = _TrackedEntity(1, "Quest")
+
+    saved = repository.save(entity)
+    assert saved is entity
+    assert repository.get_by_id(1) is entity
+    assert repository.list() == [entity]
+    assert repository.delete(1) is True
+    assert repository.get_by_id(1) is None
+
+
+def test_in_memory_repository_requires_identifier() -> None:
+    repository: InMemoryRepository[_TrackedEntity, int] = InMemoryRepository()
+
+    with pytest.raises(RepositoryError):
+        repository.save(_TrackedEntity(None, "Missing Id"))
+
+
+def test_in_memory_repository_conforms_to_protocol() -> None:
+    repository = InMemoryRepository[_TrackedEntity, int]()
+
+    assert isinstance(repository, RepositoryProtocol)

--- a/life_dashboard/shared/tests/test_unit_of_work.py
+++ b/life_dashboard/shared/tests/test_unit_of_work.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import pytest
+
+from life_dashboard.shared.domain.exceptions import TransactionError
+from life_dashboard.shared.domain.model import Entity
+from life_dashboard.shared.domain.repository import InMemoryRepository
+from life_dashboard.shared.domain.unit_of_work import (
+    AbstractUnitOfWork,
+    InMemoryUnitOfWork,
+)
+
+
+class _StubEntity(Entity[int]):
+    def __init__(self, entity_id: int | None, name: str) -> None:
+        super().__init__(entity_id)
+        self.id = entity_id
+        self.name = name
+
+
+def _persist_entity(uow: AbstractUnitOfWork, repository: InMemoryRepository[_StubEntity, int], entity: _StubEntity) -> None:
+    uow.register_operation(lambda: repository.save(entity))
+
+
+def test_unit_of_work_commits_registered_operations() -> None:
+    repository: InMemoryRepository[_StubEntity, int] = InMemoryRepository()
+    uow = InMemoryUnitOfWork()
+
+    entity = _StubEntity(1, "Alpha")
+
+    with uow:
+        _persist_entity(uow, repository, entity)
+        assert repository.get_by_id(1) is None
+
+    assert repository.get_by_id(1) is entity
+    assert uow.committed is True
+    assert uow.rolled_back is False
+    assert uow.commit_calls == 1
+
+
+def test_unit_of_work_rolls_back_on_error() -> None:
+    repository: InMemoryRepository[_StubEntity, int] = InMemoryRepository()
+    uow = InMemoryUnitOfWork()
+
+    with pytest.raises(RuntimeError):
+        with uow:
+            _persist_entity(uow, repository, _StubEntity(2, "Beta"))
+            raise RuntimeError("fail to commit")
+
+    assert repository.get_by_id(2) is None
+    assert uow.rolled_back is True
+    assert uow.rollback_calls == 1
+
+
+def test_register_operation_requires_active_transaction() -> None:
+    uow = InMemoryUnitOfWork()
+
+    with pytest.raises(TransactionError):
+        uow.register_operation(lambda: None)
+
+
+def test_atomic_operation_executes_and_commits() -> None:
+    repository: InMemoryRepository[_StubEntity, int] = InMemoryRepository()
+    uow = InMemoryUnitOfWork()
+
+    def operation(active_uow: AbstractUnitOfWork) -> str:
+        entity = _StubEntity(3, "Gamma")
+        active_uow.register_operation(lambda: repository.save(entity))
+        return entity.name
+
+    result = uow.run_atomic(operation)
+
+    assert result == "Gamma"
+    assert repository.get_by_id(3) is not None
+    assert uow.committed is True
+
+
+def test_atomic_operation_rolls_back_on_exception() -> None:
+    repository: InMemoryRepository[_StubEntity, int] = InMemoryRepository()
+    uow = InMemoryUnitOfWork()
+
+    def operation(active_uow: AbstractUnitOfWork) -> None:
+        entity = _StubEntity(4, "Delta")
+        active_uow.register_operation(lambda: repository.save(entity))
+        raise ValueError("boom")
+
+    with pytest.raises(ValueError):
+        uow.run_atomic(operation)
+
+    assert repository.get_by_id(4) is None
+    assert uow.rolled_back is True


### PR DESCRIPTION
## Summary
- add shared kernel entity/value object primitives with event tracking and validation hooks
- introduce repository contracts, shared exceptions, and a reusable in-memory repository implementation
- implement unit of work transaction orchestration with atomic execution support and unit tests for the shared kernel

## Testing
- pytest life_dashboard/shared/tests -q

------
https://chatgpt.com/codex/tasks/task_e_68d087b7105c8323b268cef9eb078330