### PR TITLE
BLA-10: [dashboard] Support custom auth user model for profiles

### DIFF
--- a/life_dashboard/dashboard/apps.py
+++ b/life_dashboard/dashboard/apps.py
@@ -1,6 +1,23 @@
 from django.apps import AppConfig
 
 
+def _connect_signals():
+    """Connect dashboard signal handlers safely during app ready."""
+    from django.contrib.auth import get_user_model
+    from django.db.models.signals import post_save
+
+    from .models import create_user_profile
+
+    post_save.connect(
+        create_user_profile,
+        sender=get_user_model(),
+        dispatch_uid="life_dashboard.dashboard.create_user_profile",
+    )
+
+
 class DashboardConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "life_dashboard.dashboard"
+
+    def ready(self):
+        _connect_signals()

--- a/life_dashboard/dashboard/models.py
+++ b/life_dashboard/dashboard/models.py
@@ -1,15 +1,15 @@
 import logging
 
-from django.contrib.auth.models import User
+from django.conf import settings
 from django.db import models
-from django.db.models.signals import post_save
-from django.dispatch import receiver
 
 logger = logging.getLogger(__name__)
 
 
 class UserProfile(models.Model):
-    user = models.OneToOneField(User, on_delete=models.CASCADE, related_name="profile")
+    user = models.OneToOneField(
+        settings.AUTH_USER_MODEL, on_delete=models.CASCADE, related_name="profile"
+    )
     bio = models.TextField(max_length=500, blank=True)
     location = models.CharField(max_length=30, blank=True)
     birth_date = models.DateField(null=True, blank=True)
@@ -79,7 +79,6 @@ class UserProfile(models.Model):
 
 
 # Keep only one signal handler for creating UserProfile
-@receiver(post_save, sender=User)
 def create_user_profile(sender, instance, created, **kwargs):
     """Create a UserProfile when a User is created."""
     if created:

--- a/life_dashboard/dashboard/tests/test_user_profile_model.py
+++ b/life_dashboard/dashboard/tests/test_user_profile_model.py
@@ -1,0 +1,30 @@
+"""Tests for the dashboard's UserProfile model integration with the auth user model."""
+
+from unittest import mock
+
+from django.contrib.auth import get_user_model
+
+from life_dashboard.dashboard.apps import _connect_signals
+from life_dashboard.dashboard.models import UserProfile, create_user_profile
+
+
+def test_user_profile_relates_to_active_user_model():
+    """Ensure the UserProfile FK points to the active auth user model."""
+    user_field = UserProfile._meta.get_field("user")
+
+    assert user_field.remote_field.model is get_user_model()
+
+
+@mock.patch("django.db.models.signals.post_save.connect")
+def test_signal_connection_uses_runtime_user_model(mock_connect):
+    """The signal hookup should resolve the user model at runtime."""
+    user_model = get_user_model()
+
+    with mock.patch("django.contrib.auth.get_user_model", return_value=user_model):
+        _connect_signals()
+
+    mock_connect.assert_called_with(
+        create_user_profile,
+        sender=user_model,
+        dispatch_uid="life_dashboard.dashboard.create_user_profile",
+    )


### PR DESCRIPTION
## Summary
- update the `UserProfile` relation to use `settings.AUTH_USER_MODEL`
- register the profile creation signal in `DashboardConfig.ready()` with `get_user_model()`
- add tests covering the model relation and runtime signal wiring

## Testing
- python manage.py makemigrations
- pytest life_dashboard/dashboard/tests/test_user_profile_model.py
- ruff check life_dashboard/dashboard/apps.py life_dashboard/dashboard/models.py life_dashboard/dashboard/tests/test_user_profile_model.py

------
https://chatgpt.com/codex/tasks/task_e_68d088618e088323b7b4093896fc2ab4