### PR TITLE
[dashboard] Reset DB via migrations

### DIFF
--- a/life_dashboard/dashboard/management/commands/resetdb.py
+++ b/life_dashboard/dashboard/management/commands/resetdb.py
@@ -19,13 +19,13 @@ class Command(BaseCommand):
             help="Do not prompt for confirmation.",
         )
         parser.add_argument(
-            "--database",
+            "--using",
             default=DEFAULT_DB_ALIAS,
             help="Database alias to reset (default: default).",
         )
 
     def handle(self, *args, **options):
-        database = options["database"]
+        database = options["using"]
         noinput = options["noinput"]
         auto_confirm = (
             noinput

--- a/life_dashboard/dashboard/management/commands/resetdb.py
+++ b/life_dashboard/dashboard/management/commands/resetdb.py
@@ -10,7 +10,7 @@ from life_dashboard.dashboard.utils import reset_database
 
 
 class Command(BaseCommand):
-    help = "Resets the database by dropping all tables and recreating them"
+    help = "Resets the database by migrating to zero and reapplying migrations"
 
     def add_arguments(self, parser):
         parser.add_argument(
@@ -59,7 +59,7 @@ class Command(BaseCommand):
         self.stdout.write("Resetting the database...")
 
         try:
-            reset_database(database=database)
+            reset_database(using=database)
             self.stdout.write(self.style.SUCCESS("Database reset successfully!"))
         except RuntimeError as exc:
             message = str(exc)

--- a/life_dashboard/dashboard/management/commands/resetdb.py
+++ b/life_dashboard/dashboard/management/commands/resetdb.py
@@ -20,6 +20,8 @@ class Command(BaseCommand):
         )
         parser.add_argument(
             "--using",
+            "--database",
+            dest="using",
             default=DEFAULT_DB_ALIAS,
             help="Database alias to reset (default: default).",
         )

--- a/life_dashboard/dashboard/utils/__init__.py
+++ b/life_dashboard/dashboard/utils/__init__.py
@@ -32,7 +32,13 @@ def reset_database(*, using: str = DEFAULT_DB_ALIAS) -> None:
     logger.info("Resetting database '%s' by migrating to zero.", using)
 
     executor = MigrationExecutor(connection)
-    executor.migrate(targets=[])
+    migrated_apps = sorted(executor.loader.migrated_apps)
+    zero_targets = [(app_label, None) for app_label in migrated_apps]
+
+    if zero_targets:
+        executor.migrate(zero_targets)
+    else:
+        logger.info("No migrated apps detected for database '%s'.", using)
 
     logger.info("Reapplying migrations for database '%s'.", using)
     call_command("migrate", database=using, interactive=False, verbosity=0)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,6 +138,7 @@ markers = [
     "contract: marks tests as contract/API tests with Pydantic validation",
     "property: marks property-based tests using Hypothesis",
     "snapshot: marks snapshot tests for API responses",
+    "django_db: marks tests that interact with the Django database",
 ]
 
 [tool.coverage.run]

--- a/tests/dashboard/test_reset_database.py
+++ b/tests/dashboard/test_reset_database.py
@@ -1,0 +1,40 @@
+"""Tests for the dashboard database reset helper."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from django.db import DEFAULT_DB_ALIAS, connections
+
+from life_dashboard.dashboard.utils import reset_database
+
+
+@pytest.mark.django_db
+def test_reset_database_migrates_to_zero_and_reapplies(settings, monkeypatch):
+    """Ensure the reset helper migrates to zero before reapplying migrations."""
+
+    settings.DEBUG = True
+    monkeypatch.setenv("DJANGO_ENV", "development")
+
+    migrated_apps = {"app_one", "app_two"}
+
+    fake_executor = MagicMock()
+    fake_executor.loader.migrated_apps = migrated_apps
+
+    executor_cls = MagicMock(return_value=fake_executor)
+    monkeypatch.setattr("life_dashboard.dashboard.utils.MigrationExecutor", executor_cls)
+
+    call_command_mock = MagicMock()
+    monkeypatch.setattr("life_dashboard.dashboard.utils.call_command", call_command_mock)
+
+    reset_database()
+
+    executor_cls.assert_called_once_with(connections[DEFAULT_DB_ALIAS])
+
+    expected_zero_targets = [(app_label, None) for app_label in sorted(migrated_apps)]
+    fake_executor.migrate.assert_called_once_with(expected_zero_targets)
+
+    call_command_mock.assert_called_once_with(
+        "migrate", database=DEFAULT_DB_ALIAS, interactive=False, verbosity=0
+    )

--- a/tests/dashboard/test_reset_management_command.py
+++ b/tests/dashboard/test_reset_management_command.py
@@ -1,0 +1,22 @@
+"""Tests for the resetdb management command."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from django.core.management import call_command
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("option", ["--using=analytics", "--database=analytics"])
+def test_resetdb_command_forwards_using_alias(option, settings, monkeypatch):
+    """Ensure the command forwards the provided alias to the helper."""
+
+    settings.DEBUG = True
+    monkeypatch.setenv("DJANGO_ENV", "development")
+
+    with patch("life_dashboard.dashboard.management.commands.resetdb.reset_database") as reset:
+        call_command("resetdb", "--noinput", option)
+
+    reset.assert_called_once_with(using="analytics")


### PR DESCRIPTION
## Summary
- replace the dashboard reset utility with a migration-driven database reset that works across backends
- log the reset lifecycle and reapply migrations after migrating to zero
- align the resetdb management command messaging and usage with the new helper signature

## Testing
- pytest
- ruff check .
- mypy .

------
https://chatgpt.com/codex/tasks/task_e_68d0886b99a083239fbbe42b38f19e4e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Reset workflow now rolls back all migrations to zero and reapplies them, providing a safer, database-agnostic reset. Renamed command option from “database” to “using” for consistency. Added logging to show progress during reset.
- Bug Fixes
  - Clearer, more informative errors for operational and integrity issues during reset, improving troubleshooting.
- Documentation
  - Updated command help text to describe the new migration-based reset process, clarifying behaviour for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->